### PR TITLE
[WIP] Validate the type of context argument

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,7 +50,6 @@
 - [ ] Improve playground
   - Could we actually evaluate the resolvers? Maybe in a worker?
   - Could we hook up GraphiQL 2?
-- [ ] Can we ensure the context and ast arguments of resolvers are correct?
 - [ ] Can we use TypeScript's inference to infer types?
   - [ ] For example, a method which returns a string, or a property that has a default value.
 - [ ] Define resolvers?

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -248,7 +248,7 @@ export function pluralTypeMissingParameter() {
   return `Expected type reference to have type arguments.`;
 }
 
-export function expectedIdentifer() {
+export function expectedIdentifier() {
   return "Expected an identifier.";
 }
 
@@ -322,4 +322,34 @@ export function invalidTypePassedToFieldFunction() {
 
 export function unresolvedTypeReference() {
   return "This type is not a valid GraphQL type. Did you mean to annotate it's definition with a `/** @gql */` tag such as `/** @gqlType */` or `/** @gqlInput **/`?";
+}
+
+export function expectedTypeAnnotationOnContext() {
+  return "Expected context parameter to have a type annotation. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.";
+}
+
+export function expectedTypeAnnotationOfReferenceOnContext() {
+  return "Expected context parameter's type to be a type reference. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.";
+}
+
+export function expectedTypeAnnotationOnContextToBeResolvable() {
+  // TODO: Provide guidance?
+  return "Unable to resolve the type of the context parameter. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.";
+}
+
+export function expectedTypeAnnotationOnContextToHaveDeclaration() {
+  // TODO: Provide guidance?
+  return "Unable to locate the declaration of the type of the context parameter. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`. Did you mean to import or define this type?";
+}
+
+export function expectedTypeAnnotationOnContextToHaveContextTag() {
+  return "Expected the definition of the context type to be annotated with `/** @gqlContext */`. Did you mean to add that annotation?";
+}
+
+export function duplicateContextDeclaration() {
+  return "Unexpected duplicate declaration of `/** @gqlContext */`. Grats expects there to be only one context type.";
+}
+
+export function unexpectedParamSpreadForContextParam() {
+  return "Unexpected spread parameter in context parameter position. Grats expects the context parameter to be a single, explicitly typed, argument.";
 }

--- a/src/TypeContext.ts
+++ b/src/TypeContext.ts
@@ -43,6 +43,10 @@ export type AbstractFieldDefinitionNode = {
   readonly field: FieldDefinitionNode;
 };
 
+type ContextDeclaration = {
+  node: ts.Node;
+};
+
 /**
  * Used to track TypeScript references.
  *
@@ -62,6 +66,8 @@ export class TypeContext {
   _options: ts.ParsedCommandLine;
   _symbolToName: Map<ts.Symbol, NameDefinition> = new Map();
   _unresolvedTypes: Map<NameNode, ts.Symbol> = new Map();
+  // The `@gqlContext` declaration, if it has been encountered.
+  contextDeclaration: ContextDeclaration | null = null;
   hasTypename: Set<string> = new Set();
 
   constructor(

--- a/src/tests/fixtures/arguments/NoArgsWithNever.ts
+++ b/src/tests/fixtures/arguments/NoArgsWithNever.ts
@@ -1,8 +1,8 @@
 /** @gqlType */
 export default class Query {
   /** @gqlField */
-  hello(args: never, ctx: any): string {
-    console.log(ctx);
+  hello(args: never): string {
+    console.log("hello");
     return "Hello world!";
   }
 }

--- a/src/tests/fixtures/arguments/NoArgsWithNever.ts.expected
+++ b/src/tests/fixtures/arguments/NoArgsWithNever.ts.expected
@@ -4,8 +4,8 @@ INPUT
 /** @gqlType */
 export default class Query {
   /** @gqlField */
-  hello(args: never, ctx: any): string {
-    console.log(ctx);
+  hello(args: never): string {
+    console.log("hello");
     return "Hello world!";
   }
 }

--- a/src/tests/fixtures/interfaces/tag/ImplementsTagWithoutTypeOrInterface.invalid.ts.expected
+++ b/src/tests/fixtures/interfaces/tag/ImplementsTagWithoutTypeOrInterface.invalid.ts.expected
@@ -9,7 +9,7 @@ function hello() {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/interfaces/tag/ImplementsTagWithoutTypeOrInterface.invalid.ts:1:6 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/interfaces/tag/ImplementsTagWithoutTypeOrInterface.invalid.ts:1:6 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 1 /** @gqlImplements Node */
        ~~~~~~~~~~~~~

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts
@@ -1,0 +1,12 @@
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
@@ -1,0 +1,30 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  query: Query
+}
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type Query {
+  greeting: String
+}

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts
@@ -1,0 +1,12 @@
+/** @gqlContext */
+export type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
@@ -1,0 +1,30 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlContext */
+export type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  query: Query
+}
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type Query {
+  greeting: String
+}

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts
@@ -1,0 +1,12 @@
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts.expected
@@ -1,0 +1,23 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(ctx: GratsContext): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts:9:17 - error: Expected GraphQL field arguments to be typed using a literal object: `{someField: string}`.
+
+9   greeting(ctx: GratsContext): string {
+                  ~~~~~~~~~~~~

--- a/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts:4:25 - error: Expected context parameter to have a type annotation. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.
+
+4   greeting(args: never, ctx): string {
+                          ~~~

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts
@@ -1,0 +1,13 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx?: SomeType): string {
+    // This is fine since Grats will always pass ctx. It's fine for
+    // the resolver to _also_ work _without_ ctx, as long as it's
+    // safe for Grats to pass ctx.
+    return ctx?.greeting ?? "Hello, World!";
+  }
+}
+
+/** @gqlContext */
+type SomeType = { greeting: string };

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
@@ -1,0 +1,31 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx?: SomeType): string {
+    // This is fine since Grats will always pass ctx. It's fine for
+    // the resolver to _also_ work _without_ ctx, as long as it's
+    // safe for Grats to pass ctx.
+    return ctx?.greeting ?? "Hello, World!";
+  }
+}
+
+/** @gqlContext */
+type SomeType = { greeting: string };
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  query: Query
+}
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type Query {
+  greeting: String
+}

--- a/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts
@@ -1,0 +1,10 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ...ctx: SomeType): string {
+    return ctx[0].greeting;
+  }
+}
+
+/** @gqlContext */
+type SomeType = { greeting: string };

--- a/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts.expected
@@ -1,0 +1,21 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ...ctx: SomeType): string {
+    return ctx[0].greeting;
+  }
+}
+
+/** @gqlContext */
+type SomeType = { greeting: string };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts:4:25 - error: Unexpected spread parameter in context parameter position. Grats expects the context parameter to be a single, explicitly typed, argument.
+
+4   greeting(args: never, ...ctx: SomeType): string {
+                          ~~~

--- a/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: ThisIsNeverDefined): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: ThisIsNeverDefined): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts:4:30 - error: Unable to locate the declaration of the type of the context parameter. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`. Did you mean to import or define this type?
+
+4   greeting(args: never, ctx: ThisIsNeverDefined): string {
+                               ~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: any): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: any): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts:4:30 - error: Expected context parameter's type to be a type reference. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.
+
+4   greeting(args: never, ctx: any): string {
+                               ~~~

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: { greeting: string }): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: { greeting: string }): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts:4:30 - error: Expected context parameter's type to be a type reference. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.
+
+4   greeting(args: never, ctx: { greeting: string }): string {
+                               ~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: never): string {
+    return ctx.greeting;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: never): string {
+    return ctx.greeting;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts:4:30 - error: Expected context parameter's type to be a type reference. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.
+
+4   greeting(args: never, ctx: never): string {
+                               ~~~~~

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: string): string {
+    return ctx;
+  }
+}

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Query {
+  /** @gqlField */
+  greeting(args: never, ctx: string): string {
+    return ctx;
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts:4:30 - error: Expected context parameter's type to be a type reference. Grats validates that your context parameter is type-safe by checking that it references the type declaration annotated with `/** @gqlContext */`.
+
+4   greeting(args: never, ctx: string): string {
+                               ~~~~~~

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts
@@ -1,0 +1,12 @@
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class User {}
+
+/** @gqlField */
+export function greeting(_: User, args: never, ctx: GratsContext): string {
+  return ctx.greeting;
+}

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
@@ -1,0 +1,26 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlContext */
+type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlType */
+export class User {}
+
+/** @gqlField */
+export function greeting(_: User, args: never, ctx: GratsContext): string {
+  return ctx.greeting;
+}
+
+-----------------
+OUTPUT
+-----------------
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type User {
+  greeting: String @exported(filename: "tests/fixtures/resolver_context/FunctionWithContextValue.js", functionName: "greeting")
+}

--- a/src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts
+++ b/src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts
@@ -1,0 +1,9 @@
+/** @gqlContext */
+export type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlContext */
+export type AlsoGratsContext = {
+  greeting: string;
+};

--- a/src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts.expected
@@ -1,0 +1,25 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlContext */
+export type GratsContext = {
+  greeting: string;
+};
+
+/** @gqlContext */
+export type AlsoGratsContext = {
+  greeting: string;
+};
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts:6:6 - error: Unexpected duplicate declaration of `/** @gqlContext */`. Grats expects there to be only one context type.
+
+6 /** @gqlContext */
+       ~~~~~~~~~~
+
+  src/tests/fixtures/resolver_context/MultipleContextTags.invalid.ts:1:5
+    1 /** @gqlContext */
+          ~~~~~~~~~~~~
+    Previous context declaration

--- a/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterfaceWithDeprecatedTag.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterfaceWithDeprecatedTag.invalid.ts.expected
@@ -26,7 +26,7 @@ src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterfaceWi
       ~~~~~~~~~~~~~~~~~~~~~
 10  */
    ~
-src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterfaceWithDeprecatedTag.invalid.ts:9:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterfaceWithDeprecatedTag.invalid.ts:9:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 9  * @gqlImplements Person
       ~~~~~~~~~~~~~

--- a/src/tests/fixtures/type_definitions_from_alias/AliasTypeImplementsInterface.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasTypeImplementsInterface.invalid.ts.expected
@@ -26,7 +26,7 @@ src/tests/fixtures/type_definitions_from_alias/AliasTypeImplementsInterface.inva
      ~~~~~~~~~~~~~~~~~~~~~
 4  */
   ~
-src/tests/fixtures/type_definitions_from_alias/AliasTypeImplementsInterface.invalid.ts:3:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/type_definitions_from_alias/AliasTypeImplementsInterface.invalid.ts:3:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 3  * @gqlImplements Person
       ~~~~~~~~~~~~~

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterfaceWithDeprecatedTag.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterfaceWithDeprecatedTag.invalid.ts.expected
@@ -27,7 +27,7 @@ src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterf
       ~~~~~~~~~~~~~~~~~~~~~
 10  */
    ~
-src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterfaceWithDeprecatedTag.invalid.ts:9:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterfaceWithDeprecatedTag.invalid.ts:9:5 - error: `@gqlImplements` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 9  * @gqlImplements Person
       ~~~~~~~~~~~~~

--- a/src/tests/fixtures/user_error/GqlTagDoesNotExist.ts.expected
+++ b/src/tests/fixtures/user_error/GqlTagDoesNotExist.ts.expected
@@ -6,7 +6,7 @@ INPUT
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/user_error/GqlTagDoesNotExist.ts:1:6 - error: `@gqlFiled` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/user_error/GqlTagDoesNotExist.ts:1:6 - error: `@gqlFiled` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 1 /** @gqlFiled */
        ~~~~~~~~

--- a/src/tests/fixtures/user_error/WrongCaseGqlTag.ts.expected
+++ b/src/tests/fixtures/user_error/WrongCaseGqlTag.ts.expected
@@ -11,7 +11,7 @@ src/tests/fixtures/user_error/WrongCaseGqlTag.ts:1:6 - error: Incorrect casing f
 
 1 /** @GQLField */
        ~~~~~~~~
-src/tests/fixtures/user_error/WrongCaseGqlTag.ts:1:6 - error: `@GQLField` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`.
+src/tests/fixtures/user_error/WrongCaseGqlTag.ts:1:6 - error: `@GQLField` is not a valid Grats tag. Valid tags are: `@gqlType`, `@gqlField`, `@gqlScalar`, `@gqlInterface`, `@gqlEnum`, `@gqlUnion`, `@gqlInput`, `@gqlContext`.
 
 1 /** @GQLField */
        ~~~~~~~~

--- a/website/docs/04-dockblock-tags/09-context.mdx
+++ b/website/docs/04-dockblock-tags/09-context.mdx
@@ -1,0 +1,41 @@
+# Context
+
+The TypeScript type of your expected GraphQL execution context can be defined by placing a `@gqlContext` docblock directly before a:
+
+- Declaration
+
+During execution, each resolver will be passed a [context object](https://graphql.org/learn/execution/#root-fields-resolvers). Context is typically used to pass around information about the current request as well as inject database connections and other per-request caches, such as [DataLoader](https://github.com/graphql/dataloader)s into your resolvers.
+
+Ensuring your resolvers functions/methods are expecting the context object to have the correct type can be difficult. Grats solves this by expecting you to annotate your context type's declaration with a `@gqlContext` docblock:
+
+:::caution
+It is an error to have more than one `@gqlContext` docblock in your project. Grats will error if it detects more than one.
+:::
+
+```ts
+/** @gqlContext */
+type GQLCtx = {
+  req: express.Request;
+  userID: string;
+  db: Database;
+};
+
+/** @gqlField */
+export function me(_: Query, args: never, ctx: GQLCtx): User {
+  return ctx.db.users.getById(ctx.userID);
+}
+```
+
+The context argument is passed as the third argument of resovler _functions_ and the second argument of resolver _methods_. If your resolver does not need access to the context object, you can omit the context argument.
+
+:::tip
+If you need to access the context object in your resolver, but your field does not define any args, you can type your args parameter as `never`.
+:::
+
+## Constructing your context object
+
+The mechanism by which you construct your context object will vary depending upon the GraphQL server library you are using. See your GraphQL server library's documentation for more information.
+
+:::caution
+Grats can ensure that every resolver is expecting the correct context type, but it cannot ensure that your context object is constructed correctly. **It is up to you to ensure that your context object is constructed correctly and passed to the GraphQL execution engine.**
+:::


### PR DESCRIPTION
Exploring a potential solution to #21 where you declare the type of your context object using `@gqlContext`.

## TODO

- [ ] Do we need to allow you to type your ctx object as `never`? I think you could just declare a type and make that type an alias of `never`
- [ ] Provide a special helpful error message if you try to use ctx as your _first_ argument (where you should have put args)