### PR TITLE
Revert fixing promises in the playground

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
 - [ ] Write guides
   - [ ] DataLoader pattern
   - [ ] Subscriptions
+- [ ] Playground does not support promises
 - [ ] Collect deprecated tags on all nodes and let GraphQL validation report an error
 - [ ] Consider checking for @gql in non-docblock comments
 - Example that includes a mutation and query

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^18.15.0
         version: 18.15.0
       '@typescript/vfs':
-        specifier: 1.5.0
-        version: 1.5.0
+        specifier: ^1.4.0
+        version: 1.4.0
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -4390,8 +4390,8 @@ packages:
       '@typescript-eslint/types': 5.55.0
       eslint-visitor-keys: 3.3.0
 
-  /@typescript/vfs@1.5.0:
-    resolution: {integrity: sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==}
+  /@typescript/vfs@1.4.0:
+    resolution: {integrity: sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==}
     dependencies:
       debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@graphql-tools/utils": "^9.2.1",
     "@mdx-js/react": "^1.6.22",
     "@types/node": "^18.15.0",
-    "@typescript/vfs": "1.5.0",
+    "@typescript/vfs": "^1.4.0",
     "clsx": "^1.2.1",
     "cm6-graphql": "^0.0.3",
     "glob": "^9.3.4",

--- a/website/src/components/PlaygroundFeatures/linter.ts
+++ b/website/src/components/PlaygroundFeatures/linter.ts
@@ -34,7 +34,7 @@ function buildSchemaResultWithFsMap(fsMap, text, config) {
     allowJs: true,
     baseUrl: "./",
     paths: { grats: [GRATS_PATH] },
-    lib: [...fsMap.keys()],
+    // lib: ["es2021"],
   };
   const host = createVirtualCompilerHost(system, compilerOpts, ts);
 


### PR DESCRIPTION
This reverts commit bff414be7139296d30f829b876a8e3bd512dc3bd.

Revert "Just include all files in lib"

This reverts commit 06840570dde9696c7d16b0915777a4b5e7ea5293.

Revert "Enable promises for Playground. Fixes #19."

This reverts commit ec27ebe5542cc3126c7123dab758f401e626e48e.