### PR TITLE
Permit defining types as `unknown`

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -128,8 +128,8 @@ export function typeTagOnUnnamedClass() {
   return `Unexpected \`@${TYPE_TAG}\` annotation on unnamed class declaration.`;
 }
 
-export function typeTagOnAliasOfNonObject() {
-  return `Expected \`@${TYPE_TAG}\` type to be a type literal. For example: \`type Foo = { bar: string }\``;
+export function typeTagOnAliasOfNonObjectOrUnknown() {
+  return `Expected \`@${TYPE_TAG}\` type to be a type literal or \`unknown\`. For example: \`type Foo = { bar: string }\` or \`type Query = unknown\`.`;
 }
 
 export function typeNameNotDeclaration() {

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts.expected
@@ -9,9 +9,7 @@ export type Query = {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal. For example: `type Foo = { bar: string }`
-
-If you think Grats should be able to infer this type, please report an issue at https://github.com/captbaritone/grats/issues.
+src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
 
 2 export type Query = {
                       ~

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts.expected
@@ -7,9 +7,7 @@ export type Query = 10;
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal. For example: `type Foo = { bar: string }`
-
-If you think Grats should be able to infer this type, please report an issue at https://github.com/captbaritone/grats/issues.
+src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
 
 2 export type Query = 10;
                       ~~

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts
@@ -1,0 +1,7 @@
+/** @gqlType */
+export type Query = unknown;
+
+/** @gqlField */
+export function greeting(_: Query): string {
+  return "Hello world";
+}

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -1,0 +1,25 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export type Query = unknown;
+
+/** @gqlField */
+export function greeting(_: Query): string {
+  return "Hello world";
+}
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  query: Query
+}
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type Query {
+  greeting: String @exported(filename: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", functionName: "greeting")
+}

--- a/website/docs/04-dockblock-tags/01-types.mdx
+++ b/website/docs/04-dockblock-tags/01-types.mdx
@@ -12,7 +12,7 @@ GraphQL types can be defined by placing a `@gqlType` docblock directly before a:
 
 - Class declaration
 - Interface declaration
-- Type alias of a literal type
+- Type alias of a literal type or `unknown`
 
 If model your GraphQL resolvers using classes, simply add a `@gqlType` docblock
 before the class conaining that type's resolvers.


### PR DESCRIPTION
For root types (`Query`, `Mutation`, `Subscription`) in most cases, it makes more sense to write them as an alias of `unknown` since we can't know at compile time what the executor will pass. I also suspect there are very few places where you actually need to define a root object where you wouldn't be better served exposing that data on context.

I suspect I will followup with a change which _requires_ that you model top level types as `unknown`, at least for now. We may followup with something more advanced such as what's outlined here: https://github.com/captbaritone/grats/issues/13#issuecomment-1797105101.