### PR TITLE
Don't use Query in tests that are not specific to operations

### DIFF
--- a/src/tests/fixtures/arguments/ArgWithNoType.invalid.ts
+++ b/src/tests/fixtures/arguments/ArgWithNoType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/ArgWithNoType.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/ArgWithNoType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/ArgumentWithDescription.ts
+++ b/src/tests/fixtures/arguments/ArgumentWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: {
     /** The greeting to use. */

--- a/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
+++ b/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: {
     /** The greeting to use. */
@@ -15,15 +15,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(
     """The greeting to use."""
     greeting: String!

--- a/src/tests/fixtures/arguments/CustomScalarArgument.ts
+++ b/src/tests/fixtures/arguments/CustomScalarArgument.ts
@@ -2,7 +2,7 @@
 type MyString = string;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: MyString }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
+++ b/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
@@ -5,7 +5,7 @@ INPUT
 type MyString = string;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: MyString }): string {
     return "Hello world!";
@@ -15,16 +15,12 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 scalar MyString
 
-type Query {
+type SomeType {
   hello(greeting: MyString!): String
 }

--- a/src/tests/fixtures/arguments/DeprecatedArgument.ts
+++ b/src/tests/fixtures/arguments/DeprecatedArgument.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({
     greeting,

--- a/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
+++ b/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({
     greeting,
@@ -17,14 +17,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(greeting: String @deprecated(reason: "Not used anymore")): String
 }

--- a/src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts
+++ b/src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({
     greeting,

--- a/src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({
     greeting,
@@ -17,7 +17,7 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts:7:10 - error: Required argument Query.hello(greeting:) cannot be deprecated.
+src/tests/fixtures/arguments/DeprecatedRequiredArgument.invalid.ts:7:10 - error: Required argument SomeType.hello(greeting:) cannot be deprecated.
 
 7     /** @deprecated Not used anymore */
            ~~~~~~~~~~

--- a/src/tests/fixtures/arguments/NoArgsWithNever.ts
+++ b/src/tests/fixtures/arguments/NoArgsWithNever.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: never): string {
     console.log("hello");

--- a/src/tests/fixtures/arguments/NoArgsWithNever.ts.expected
+++ b/src/tests/fixtures/arguments/NoArgsWithNever.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: never): string {
     console.log("hello");

--- a/src/tests/fixtures/arguments/NoArgsWithUnknown.ts
+++ b/src/tests/fixtures/arguments/NoArgsWithUnknown.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: unknown): string {
     console.log("hello");

--- a/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
+++ b/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: unknown): string {
     console.log("hello");
@@ -13,14 +13,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/arguments/NoTypeAnnotation.invalid.ts
+++ b/src/tests/fixtures/arguments/NoTypeAnnotation.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/NoTypeAnnotation.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/NoTypeAnnotation.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/NullableArgument.ts
+++ b/src/tests/fixtures/arguments/NullableArgument.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello1({ greeting }: { greeting: string | null }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/NullableArgument.ts.expected
+++ b/src/tests/fixtures/arguments/NullableArgument.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello1({ greeting }: { greeting: string | null }): string {
     return "Hello world!";
@@ -32,15 +32,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello1(greeting: String): String
   hello2(greeting: String): String
   hello3(greeting: String): String

--- a/src/tests/fixtures/arguments/ObjectLiteralArgument.invalid.ts
+++ b/src/tests/fixtures/arguments/ObjectLiteralArgument.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: { foo: string; bar: string } }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/ObjectLiteralArgument.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/ObjectLiteralArgument.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: { foo: string; bar: string } }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/OpaqueArgType.invalid.ts
+++ b/src/tests/fixtures/arguments/OpaqueArgType.invalid.ts
@@ -1,7 +1,7 @@
 type SomeType = any;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: SomeType): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/OpaqueArgType.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/OpaqueArgType.invalid.ts.expected
@@ -4,7 +4,7 @@ INPUT
 type SomeType = any;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: SomeType): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/OptionalArgument.ts
+++ b/src/tests/fixtures/arguments/OptionalArgument.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting?: string | null }): string {
     return `${greeting ?? "Hello"} World!`;

--- a/src/tests/fixtures/arguments/OptionalArgument.ts.expected
+++ b/src/tests/fixtures/arguments/OptionalArgument.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting?: string | null }): string {
     return `${greeting ?? "Hello"} World!`;
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(greeting: String): String
 }

--- a/src/tests/fixtures/arguments/PromiseArgument.invalid.ts
+++ b/src/tests/fixtures/arguments/PromiseArgument.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: { greeting: Promise<string> }): string {
     return `${args.greeting} world!`;

--- a/src/tests/fixtures/arguments/PromiseArgument.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/PromiseArgument.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: { greeting: Promise<string> }): string {
     return `${args.greeting} world!`;

--- a/src/tests/fixtures/arguments/StringArgument.ts
+++ b/src/tests/fixtures/arguments/StringArgument.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: string }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/StringArgument.ts.expected
+++ b/src/tests/fixtures/arguments/StringArgument.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: string }): string {
     return "Hello world!";
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(greeting: String!): String
 }

--- a/src/tests/fixtures/arguments/TupleLiteralArgument.invalid.ts
+++ b/src/tests/fixtures/arguments/TupleLiteralArgument.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: [string] }): string {
     return "Hello world!";

--- a/src/tests/fixtures/arguments/TupleLiteralArgument.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/TupleLiteralArgument.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting }: { greeting: [string] }): string {
     return "Hello world!";

--- a/src/tests/fixtures/built_in_scalars/FloatField.ts
+++ b/src/tests/fixtures/built_in_scalars/FloatField.ts
@@ -1,7 +1,7 @@
 import { Float } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   ratio(): Float {
     return 10;

--- a/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Float } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   ratio(): Float {
     return 10;
@@ -14,14 +14,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   ratio: Float
 }

--- a/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts
+++ b/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts
@@ -1,7 +1,7 @@
 import { Float as LocalFloat } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   ratio(): LocalFloat {
     return 10;

--- a/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Float as LocalFloat } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   ratio(): LocalFloat {
     return 10;
@@ -14,14 +14,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   ratio: Float
 }

--- a/src/tests/fixtures/built_in_scalars/IdField.ts
+++ b/src/tests/fixtures/built_in_scalars/IdField.ts
@@ -1,7 +1,7 @@
 import { ID } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   id(): ID {
     return "QUERY_ID";

--- a/src/tests/fixtures/built_in_scalars/IdField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IdField.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { ID } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   id(): ID {
     return "QUERY_ID";
@@ -14,14 +14,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   id: ID
 }

--- a/src/tests/fixtures/built_in_scalars/IntField.ts
+++ b/src/tests/fixtures/built_in_scalars/IntField.ts
@@ -1,7 +1,7 @@
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   age(): Int {
     return 10;

--- a/src/tests/fixtures/built_in_scalars/IntField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IntField.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   age(): Int {
     return 10;
@@ -14,14 +14,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   age: Int
 }

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -13,15 +13,11 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -16,15 +16,11 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts
+++ b/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -13,15 +13,11 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/default_values/DefaultArgumentArray.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentArray.ts
@@ -1,7 +1,7 @@
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ inputs = ["hello", "there"] }: { inputs?: string[] }): string {
     return inputs.join("|");

--- a/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ inputs = ["hello", "there"] }: { inputs?: string[] }): string {
     return inputs.join("|");
@@ -14,14 +14,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   someField1(inputs: [String!] = ["hello", "there"]): String
 }

--- a/src/tests/fixtures/default_values/DefaultArgumentArrayValuesInvalid.invalid.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentArrayValuesInvalid.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ inputs = [func(), func()] }: { inputs?: string[] }): string {
     return inputs.join("|");

--- a/src/tests/fixtures/default_values/DefaultArgumentArrayValuesInvalid.invalid.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentArrayValuesInvalid.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ inputs = [func(), func()] }: { inputs?: string[] }): string {
     return inputs.join("|");

--- a/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ greet = false }: { greet?: boolean }): string {
     if (!greet) return "";

--- a/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ greet = false }: { greet?: boolean }): string {
     if (!greet) return "";
@@ -19,15 +19,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   someField1(greet: Boolean = false): String
   someField2(greet: Boolean = true): String
 }

--- a/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ hello = null }: { hello: string | null }): string {
     if (hello === null) return "hello";

--- a/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({ hello = null }: { hello: string | null }): string {
     if (hello === null) return "hello";
@@ -18,15 +18,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   someField1(hello: String = null): String
   someField2(hello: String = null): String
 }

--- a/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts
@@ -1,7 +1,7 @@
 import { Float, Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   intField({ count = 10 }: { count: Int }): string {
     return `${count} world!`;

--- a/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Float, Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   intField({ count = 10 }: { count: Int }): string {
     return `${count} world!`;
@@ -18,15 +18,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   intField(count: Int! = 10): String
   floatField(scale: Float! = 10): String
 }

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts
@@ -1,7 +1,7 @@
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first: 10, offset: 100 },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first: 10, offset: 100 },
@@ -24,15 +24,11 @@ type ConnectionInput = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   someField1(input: ConnectionInput = {first: 10, offset: 100}): String
 }
 

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralDynamicPropertyName.invalid.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralDynamicPropertyName.invalid.ts
@@ -3,7 +3,7 @@ import { Int } from "../../../Types";
 const x = "first";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { [x]: 10, offset: 100 },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralDynamicPropertyName.invalid.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralDynamicPropertyName.invalid.ts.expected
@@ -6,7 +6,7 @@ import { Int } from "../../../Types";
 const x = "first";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { [x]: 10, offset: 100 },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralInterpolation.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralInterpolation.ts
@@ -3,7 +3,7 @@ import { Int } from "../../../Types";
 const first = 10;
 const offset = 100;
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first, offset },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralInterpolation.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralInterpolation.ts.expected
@@ -6,7 +6,7 @@ import { Int } from "../../../Types";
 const first = 10;
 const offset = 100;
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first, offset },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralMultiplePropertyErrors.invalid.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralMultiplePropertyErrors.invalid.ts
@@ -1,7 +1,7 @@
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first: func(), offset: func() },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralMultiplePropertyErrors.invalid.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralMultiplePropertyErrors.invalid.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { Int } from "../../../Types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { first: func(), offset: func() },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralSpread.invalid.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralSpread.invalid.ts
@@ -3,7 +3,7 @@ import { Int } from "../../../Types";
 const defaultArgs = { first: 10, offset: 10 };
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { ...defaultArgs },

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralSpread.invalid.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteralSpread.invalid.ts.expected
@@ -6,7 +6,7 @@ import { Int } from "../../../Types";
 const defaultArgs = { first: 10, offset: 10 };
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   someField1({
     input = { ...defaultArgs },

--- a/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts
+++ b/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting = "hello" }: { greeting: string }): string {
     return `${greeting} world!`;

--- a/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting = "hello" }: { greeting: string }): string {
     return `${greeting} world!`;
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(greeting: String! = "hello"): String
 }

--- a/src/tests/fixtures/default_values/NonLiteralDefaultValue.invalid.ts
+++ b/src/tests/fixtures/default_values/NonLiteralDefaultValue.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting = String(Math.random()) }: { greeting: string }): string {
     return `${greeting} world!`;

--- a/src/tests/fixtures/default_values/NonLiteralDefaultValue.invalid.ts.expected
+++ b/src/tests/fixtures/default_values/NonLiteralDefaultValue.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello({ greeting = String(Math.random()) }: { greeting: string }): string {
     return `${greeting} world!`;

--- a/src/tests/fixtures/descriptions/MultilineDescription.ts
+++ b/src/tests/fixtures/descriptions/MultilineDescription.ts
@@ -6,7 +6,7 @@
  *
  * @gqlType
  */
-class Query {
+class SomeType {
   /** @gqlField */
   name: string;
 }

--- a/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
@@ -9,7 +9,7 @@ INPUT
  *
  * @gqlType
  */
-class Query {
+class SomeType {
   /** @gqlField */
   name: string;
 }
@@ -17,10 +17,6 @@ class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
@@ -31,6 +27,6 @@ directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITIO
 All mimsy were the borogoves,
   And the mome raths outgrabe.
 """
-type Query {
+type SomeType {
   name: String
 }

--- a/src/tests/fixtures/enums/DeprecatedEnumVariant.ts
+++ b/src/tests/fixtures/enums/DeprecatedEnumVariant.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
+++ b/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -21,15 +21,11 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/enums/Enum.ts
+++ b/src/tests/fixtures/enums/Enum.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/enums/Enum.ts.expected
+++ b/src/tests/fixtures/enums/Enum.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -16,15 +16,11 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionType.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -13,15 +13,11 @@ type MyEnum = "VALID" | "INVALID";
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionTypeNotLiteral.invalid.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeNotLiteral.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeNotLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeNotLiteral.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeNotStringLiteral.invalid.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeNotStringLiteral.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeNotStringLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeNotStringLiteral.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -16,15 +16,11 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -18,15 +18,11 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -18,15 +18,11 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -13,15 +13,11 @@ type MyEnum = "VALID";
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -16,15 +16,11 @@ type MyEnum = "VALID" | "INVALID";
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts
+++ b/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
+++ b/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -16,15 +16,11 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/enums/EnumWithDescription.ts
+++ b/src/tests/fixtures/enums/EnumWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/enums/EnumWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -20,15 +20,11 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts
+++ b/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -18,15 +18,11 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/examples/playground.ts
+++ b/src/tests/fixtures/examples/playground.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): UserResolver {
     return new UserResolver();
@@ -28,6 +28,6 @@ class UserResolver {
 }
 
 /** @gqlField */
-export function getUser(_: Query): UserResolver {
+export function getUser(_: SomeType): UserResolver {
   return new UserResolver();
 }

--- a/src/tests/fixtures/examples/playground.ts.expected
+++ b/src/tests/fixtures/examples/playground.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): UserResolver {
     return new UserResolver();
@@ -31,22 +31,18 @@ class UserResolver {
 }
 
 /** @gqlField */
-export function getUser(_: Query): UserResolver {
+export function getUser(_: SomeType): UserResolver {
   return new UserResolver();
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
   viewer: User @deprecated(reason: "Please use `me` instead.")
   getUser: User @exported(filename: "tests/fixtures/examples/playground.js", functionName: "getUser")

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -7,6 +7,6 @@ class Query {
  * @gqlField
  * @deprecated Because reasons
  */
-export function greeting(query: Query): string {
+export function greeting(query: SomeType): string {
   return "Hello world!";
 }

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -10,21 +10,17 @@ class Query {
  * @gqlField
  * @deprecated Because reasons
  */
-export function greeting(query: Query): string {
+export function greeting(query: SomeType): string {
   return "Hello world!";
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String @deprecated(reason: "Because reasons") @exported(filename: "tests/fixtures/extend_type/addDeprecatedField.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts
@@ -1,9 +1,9 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField */
-export function greeting(_: Query, args: { name: string }): string {
+export function greeting(_: SomeType, args: { name: string }): string {
   return `Hello ${args.name}!`;
 }

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
@@ -2,26 +2,22 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField */
-export function greeting(_: Query, args: { name: string }): string {
+export function greeting(_: SomeType, args: { name: string }): string {
   return `Hello ${args.name}!`;
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting(name: String!): String @exported(filename: "tests/fixtures/extend_type/addFieldWithArguments.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -7,6 +7,6 @@ class Query {
  * Best field ever!
  * @gqlField
  */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -10,22 +10,18 @@ class Query {
  * Best field ever!
  * @gqlField
  */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   """Best field ever!"""
   greeting: String @exported(filename: "tests/fixtures/extend_type/addFieldWithDescription.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts
@@ -1,9 +1,9 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField hello */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -2,26 +2,22 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField hello */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
-  hello: String @exported(filename: "tests/fixtures/extend_type/addRenamedFieldToQuery.js", functionName: "greeting") @methodName(name: "greeting")
+type SomeType {
+  hello: String @exported(filename: "tests/fixtures/extend_type/addRenamedFieldToSomeType.js", functionName: "greeting") @methodName(name: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts
@@ -1,9 +1,9 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
@@ -2,26 +2,22 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
 /** @gqlField */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world!";
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
-  greeting: String @exported(filename: "tests/fixtures/extend_type/addStringFieldToQuery.js", functionName: "greeting")
+type SomeType {
+  greeting: String @exported(filename: "tests/fixtures/extend_type/addStringFieldToSomeType.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/defaultExport.invalid.ts
+++ b/src/tests/fixtures/extend_type/defaultExport.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/defaultExport.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/defaultExport.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts
+++ b/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   foo: string;
 }

--- a/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
+++ b/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   foo: string;
 }
@@ -21,15 +21,11 @@ export function greeting(iFoo: IFoo): string {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   foo: String
 }
 

--- a/src/tests/fixtures/extend_type/missingFirstArgument.invalid.ts
+++ b/src/tests/fixtures/extend_type/missingFirstArgument.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/missingFirstArgument.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/missingFirstArgument.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/missingFirstArgumentType.invalid.ts
+++ b/src/tests/fixtures/extend_type/missingFirstArgumentType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/missingFirstArgumentType.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/missingFirstArgumentType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/nonAliasFirstArgumentType.invalid.ts
+++ b/src/tests/fixtures/extend_type/nonAliasFirstArgumentType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/nonAliasFirstArgumentType.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/nonAliasFirstArgumentType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/nonGQLFirstArgumentType.invalid.ts
+++ b/src/tests/fixtures/extend_type/nonGQLFirstArgumentType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/nonGQLFirstArgumentType.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/nonGQLFirstArgumentType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/notExported.invalid.ts
+++ b/src/tests/fixtures/extend_type/notExported.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/notExported.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/notExported.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 

--- a/src/tests/fixtures/extend_type/optionalModelType.ts
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -7,7 +7,7 @@ class Query {
 export function greeting(
   // A bit odd that this is optional, but it's fine, since we will always call
   // it with a non-null value
-  q?: Query,
+  q?: SomeType,
 ): string {
   if (q == null) {
     return "Out!";

--- a/src/tests/fixtures/extend_type/optionalModelType.ts.expected
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   // No fields
 }
 
@@ -10,7 +10,7 @@ class Query {
 export function greeting(
   // A bit odd that this is optional, but it's fine, since we will always call
   // it with a non-null value
-  q?: Query,
+  q?: SomeType,
 ): string {
   if (q == null) {
     return "Out!";
@@ -21,14 +21,10 @@ export function greeting(
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String @exported(filename: "tests/fixtures/extend_type/optionalModelType.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts
+++ b/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @deprecated Use something else.

--- a/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @deprecated Use something else.
@@ -15,14 +15,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String @deprecated(reason: "Use something else.")
 }

--- a/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts
+++ b/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @deprecated Use something else.

--- a/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @deprecated Use something else.
@@ -13,14 +13,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String @deprecated(reason: "Use something else.")
 }

--- a/src/tests/fixtures/field_definitions/FieldTagOnIncorrectNode.ts
+++ b/src/tests/fixtures/field_definitions/FieldTagOnIncorrectNode.ts
@@ -1,4 +1,4 @@
-class Query {
+class SomeType {
   /** @gqlField */
   constructor() {
     //

--- a/src/tests/fixtures/field_definitions/FieldTagOnIncorrectNode.ts.expected
+++ b/src/tests/fixtures/field_definitions/FieldTagOnIncorrectNode.ts.expected
@@ -1,7 +1,7 @@
 -----------------
 INPUT
 ----------------- 
-class Query {
+class SomeType {
   /** @gqlField */
   constructor() {
     //

--- a/src/tests/fixtures/field_definitions/FiledWithUnionOfMultipleTypes.ts
+++ b/src/tests/fixtures/field_definitions/FiledWithUnionOfMultipleTypes.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string | boolean {
     return "Hello world!";

--- a/src/tests/fixtures/field_definitions/FiledWithUnionOfMultipleTypes.ts.expected
+++ b/src/tests/fixtures/field_definitions/FiledWithUnionOfMultipleTypes.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string | boolean {
     return "Hello world!";

--- a/src/tests/fixtures/field_definitions/MethodFieldMissingType.invalid.ts
+++ b/src/tests/fixtures/field_definitions/MethodFieldMissingType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someMethodField() {
     return "Hello world!";

--- a/src/tests/fixtures/field_definitions/MethodFieldMissingType.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/MethodFieldMissingType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someMethodField() {
     return "Hello world!";

--- a/src/tests/fixtures/field_definitions/ParameterPropertyField.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public hello: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public hello: string,
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldBindingPattern.invalid.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldBindingPattern.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public [foo]: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldBindingPattern.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldBindingPattern.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public [foo]: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * @gqlField

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * @gqlField
@@ -15,14 +15,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String @deprecated(reason: "Don't use this")
 }

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     hello: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     hello: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoType.invalid.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public hello,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoType.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     public hello,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     readonly hello: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     readonly hello: string,
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * Greet the world!

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * Greet the world!

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField hello */
     public foo: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField hello */
     public foo: string,
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String @methodName(name: "foo")
 }

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * Greet the world!

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /**
      * Greet the world!
@@ -15,15 +15,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   """Greet the world!"""
   hello: String
 }

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldsNotPublic.invalid.ts
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldsNotPublic.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     private helloPrivate: string,

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldsNotPublic.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldsNotPublic.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   constructor(
     /** @gqlField */
     private helloPrivate: string,

--- a/src/tests/fixtures/field_definitions/PropertyFieldMissingType.invalid.ts
+++ b/src/tests/fixtures/field_definitions/PropertyFieldMissingType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someProp;
 }

--- a/src/tests/fixtures/field_definitions/PropertyFieldMissingType.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/PropertyFieldMissingType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someProp;
 }

--- a/src/tests/fixtures/field_definitions/ReferenceNonGraphQLType.ts
+++ b/src/tests/fixtures/field_definitions/ReferenceNonGraphQLType.ts
@@ -1,7 +1,7 @@
 type SomeUndefienedType = string;
 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   somePropertyField: SomeUndefienedType;
 }

--- a/src/tests/fixtures/field_definitions/ReferenceNonGraphQLType.ts.expected
+++ b/src/tests/fixtures/field_definitions/ReferenceNonGraphQLType.ts.expected
@@ -4,7 +4,7 @@ INPUT
 type SomeUndefienedType = string;
 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   somePropertyField: SomeUndefienedType;
 }

--- a/src/tests/fixtures/field_definitions/ReferenceUndefinedType.ts
+++ b/src/tests/fixtures/field_definitions/ReferenceUndefinedType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   somePropertyField: SomeUndefienedType;
 }

--- a/src/tests/fixtures/field_definitions/ReferenceUndefinedType.ts.expected
+++ b/src/tests/fixtures/field_definitions/ReferenceUndefinedType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   somePropertyField: SomeUndefienedType;
 }

--- a/src/tests/fixtures/field_definitions/RenamedField.ts
+++ b/src/tests/fixtures/field_definitions/RenamedField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField greeting */
   somePropertyField: string;
 

--- a/src/tests/fixtures/field_definitions/RenamedField.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField greeting */
   somePropertyField: string;
 
@@ -15,15 +15,11 @@ class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String @methodName(name: "somePropertyField")
   salutaion: String @methodName(name: "someMethodField")
 }

--- a/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts
+++ b/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /**
    * Number 1 greeting.
    *

--- a/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /**
    * Number 1 greeting.
    *
@@ -23,15 +23,11 @@ class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   """Number 1 greeting."""
   greeting: String @methodName(name: "somePropertyField")
   """Number 1 salutation."""

--- a/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts
+++ b/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * Greet the world!
    * @gqlField

--- a/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * Greet the world!
    * @gqlField
@@ -15,15 +15,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   """Greet the world!"""
   hello: String
 }

--- a/src/tests/fixtures/field_values/ArrayField.ts
+++ b/src/tests/fixtures/field_values/ArrayField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Array<string> {
     return ["Hello world!"];

--- a/src/tests/fixtures/field_values/ArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Array<string> {
     return ["Hello world!"];
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: [String!]
 }

--- a/src/tests/fixtures/field_values/ArrayOfPromises.invalid.ts
+++ b/src/tests/fixtures/field_values/ArrayOfPromises.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   b: Promise<string>[];
   /** @gqlField */

--- a/src/tests/fixtures/field_values/ArrayOfPromises.invalid.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayOfPromises.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   b: Promise<string>[];
   /** @gqlField */

--- a/src/tests/fixtures/field_values/ArrayShorthandField.ts
+++ b/src/tests/fixtures/field_values/ArrayShorthandField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string[] {
     return ["Hello world!"];

--- a/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string[] {
     return ["Hello world!"];
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: [String!]
 }

--- a/src/tests/fixtures/field_values/ArrayWithNullableItems.ts
+++ b/src/tests/fixtures/field_values/ArrayWithNullableItems.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Array<string | null> {
     return ["Hello world!", null];

--- a/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Array<string | null> {
     return ["Hello world!", null];
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: [String]
 }

--- a/src/tests/fixtures/field_values/AsyncPromiseField.ts
+++ b/src/tests/fixtures/field_values/AsyncPromiseField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   async hello(): Promise<string> {
     return "Hello world!";

--- a/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
+++ b/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   async hello(): Promise<string> {
     return "Hello world!";
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/field_values/BooleanField.ts
+++ b/src/tests/fixtures/field_values/BooleanField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   haveBeenGreeted(): boolean {
     return false;

--- a/src/tests/fixtures/field_values/BooleanField.ts.expected
+++ b/src/tests/fixtures/field_values/BooleanField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   haveBeenGreeted(): boolean {
     return false;
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   haveBeenGreeted: Boolean
 }

--- a/src/tests/fixtures/field_values/CustomScalar.ts
+++ b/src/tests/fixtures/field_values/CustomScalar.ts
@@ -2,7 +2,7 @@
 type MyString = string;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): MyString {
     return "Hello world!";

--- a/src/tests/fixtures/field_values/CustomScalar.ts.expected
+++ b/src/tests/fixtures/field_values/CustomScalar.ts.expected
@@ -5,7 +5,7 @@ INPUT
 type MyString = string;
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): MyString {
     return "Hello world!";
@@ -15,16 +15,12 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 scalar MyString
 
-type Query {
+type SomeType {
   hello: MyString
 }

--- a/src/tests/fixtures/field_values/DuplicateFields.ts
+++ b/src/tests/fixtures/field_values/DuplicateFields.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string {
     return "Hello world!";

--- a/src/tests/fixtures/field_values/DuplicateFields.ts.expected
+++ b/src/tests/fixtures/field_values/DuplicateFields.ts.expected
@@ -4,7 +4,7 @@ INPUT
 // @ts-nocheck
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string {
     return "Hello world!";
@@ -18,7 +18,7 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/field_values/DuplicateFields.ts:6:3 - error: Field "Query.hello" can only be defined once.
+src/tests/fixtures/field_values/DuplicateFields.ts:6:3 - error: Field "SomeType.hello" can only be defined once.
 
 6   hello(): string {
     ~~~~~

--- a/src/tests/fixtures/field_values/KitchenSink.ts
+++ b/src/tests/fixtures/field_values/KitchenSink.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: { greeting: string }): string {
     return `${args.greeting ?? "Hello"} world!`;

--- a/src/tests/fixtures/field_values/KitchenSink.ts.expected
+++ b/src/tests/fixtures/field_values/KitchenSink.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(args: { greeting: string }): string {
     return `${args.greeting ?? "Hello"} world!`;
@@ -61,15 +61,11 @@ class Group {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello(greeting: String!): String
   greetings(greeting: String!): [String!]
   greetings1(greeting: String!): [String!]

--- a/src/tests/fixtures/field_values/LinkedField.ts
+++ b/src/tests/fixtures/field_values/LinkedField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   async me(): Promise<User> {
     return new User();

--- a/src/tests/fixtures/field_values/LinkedField.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   async me(): Promise<User> {
     return new User();
@@ -24,15 +24,11 @@ class User {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts
+++ b/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   async me(): Promise<User<string>> {
     return new User();

--- a/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   async me(): Promise<User<string>> {
     return new User();
@@ -26,15 +26,11 @@ class User<T> {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/field_values/OptionalFields.ts
+++ b/src/tests/fixtures/field_values/OptionalFields.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string | void {
     return "Hello world!";

--- a/src/tests/fixtures/field_values/OptionalFields.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalFields.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string | void {
     return "Hello world!";
@@ -24,15 +24,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
   goodbye: String
   farewell: String

--- a/src/tests/fixtures/field_values/OptionalProperty.ts
+++ b/src/tests/fixtures/field_values/OptionalProperty.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello?: string;
 }

--- a/src/tests/fixtures/field_values/OptionalProperty.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalProperty.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello?: string;
 }
@@ -10,14 +10,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/field_values/OptionalStringFieldKillsParentOnException.invalid.ts
+++ b/src/tests/fixtures/field_values/OptionalStringFieldKillsParentOnException.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException

--- a/src/tests/fixtures/field_values/OptionalStringFieldKillsParentOnException.invalid.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalStringFieldKillsParentOnException.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException

--- a/src/tests/fixtures/field_values/ParenthesizedType.ts
+++ b/src/tests/fixtures/field_values/ParenthesizedType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): (string | null)[] {
     return ["Hello world!"];

--- a/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
+++ b/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): (string | null)[] {
     return ["Hello world!"];
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: [String]
 }

--- a/src/tests/fixtures/field_values/PromiseOfPromise.invalid.ts
+++ b/src/tests/fixtures/field_values/PromiseOfPromise.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   b: Promise<Promise<string>>;
 }

--- a/src/tests/fixtures/field_values/PromiseOfPromise.invalid.ts.expected
+++ b/src/tests/fixtures/field_values/PromiseOfPromise.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   b: Promise<Promise<string>>;
 }

--- a/src/tests/fixtures/field_values/ReadonlyArrayField.ts
+++ b/src/tests/fixtures/field_values/ReadonlyArrayField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): ReadonlyArray<string> {
     return ["Hello world!"];

--- a/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): ReadonlyArray<string> {
     return ["Hello world!"];
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: [String!]
 }

--- a/src/tests/fixtures/field_values/RenamedType.ts
+++ b/src/tests/fixtures/field_values/RenamedType.ts
@@ -5,7 +5,7 @@ class UserResolver {
 }
 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   me: UserResolver;
 }

--- a/src/tests/fixtures/field_values/RenamedType.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedType.ts.expected
@@ -8,7 +8,7 @@ class UserResolver {
 }
 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   me: UserResolver;
 }
@@ -16,10 +16,6 @@ class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
@@ -28,6 +24,6 @@ type User {
   name: String
 }
 
-type Query {
+type SomeType {
   me: User
 }

--- a/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts
+++ b/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   me: UserResolver;
 }

--- a/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   me: UserResolver;
 }
@@ -16,15 +16,11 @@ class UserResolver {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/field_values/StringField.ts
+++ b/src/tests/fixtures/field_values/StringField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string {
     return "Hello world!";

--- a/src/tests/fixtures/field_values/StringField.ts.expected
+++ b/src/tests/fixtures/field_values/StringField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): string {
     return "Hello world!";
@@ -12,14 +12,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException
@@ -15,14 +15,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String!
 }

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnExceptionWithoutNullableByDefaultEnables.invalid.ts
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnExceptionWithoutNullableByDefaultEnables.invalid.ts
@@ -1,6 +1,6 @@
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnExceptionWithoutNullableByDefaultEnables.invalid.ts.expected
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnExceptionWithoutNullableByDefaultEnables.invalid.ts.expected
@@ -3,7 +3,7 @@ INPUT
 ----------------- 
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /**
    * @gqlField
    * @killsParentOnException

--- a/src/tests/fixtures/field_values/UnionField.ts
+++ b/src/tests/fixtures/field_values/UnionField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/field_values/UnionField.ts.expected
+++ b/src/tests/fixtures/field_values/UnionField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }
@@ -29,15 +29,11 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Actor
 }
 

--- a/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts
+++ b/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts
@@ -1,6 +1,6 @@
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Promise<string> {
     return Promise.resolve("Hello world!");

--- a/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
@@ -3,7 +3,7 @@ INPUT
 ----------------- 
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Promise<string> {
     return Promise.resolve("Hello world!");
@@ -13,14 +13,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String!
 }

--- a/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts
+++ b/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts
@@ -1,6 +1,6 @@
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Promise<string | void> {
     return Promise.resolve("Hello world!");

--- a/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
@@ -3,7 +3,7 @@ INPUT
 ----------------- 
 // { "nullableByDefault": false }
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello(): Promise<string | void> {
     return Promise.resolve("Hello world!");
@@ -13,14 +13,10 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/input_types/DeprecatedInputType.invalid.ts
+++ b/src/tests/fixtures/input_types/DeprecatedInputType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/DeprecatedInputType.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/DeprecatedInputType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputType.ts
+++ b/src/tests/fixtures/input_types/InputType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputType.ts.expected
+++ b/src/tests/fixtures/input_types/InputType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -15,15 +15,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/input_types/InputTypeOptionalField.ts
+++ b/src/tests/fixtures/input_types/InputTypeOptionalField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -15,15 +15,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts
+++ b/src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts
@@ -1,10 +1,10 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someField(args: { input: MyInputType }): string;
 }
 
 /** @gqlInput */
 type MyInputType = {
-  someField: Query;
+  someField: SomeType;
 };

--- a/src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts.expected
@@ -2,20 +2,20 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   someField(args: { input: MyInputType }): string;
 }
 
 /** @gqlInput */
 type MyInputType = {
-  someField: Query;
+  someField: SomeType;
 };
 
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts:9:14 - error: The type of MyInputType.someField must be Input Type but got: Query!.
+src/tests/fixtures/input_types/InputTypeReferencingOutputType.invalid.ts:9:14 - error: The type of MyInputType.someField must be Input Type but got: SomeType!.
 
-9   someField: Query;
-               ~~~~~
+9   someField: SomeType;
+               ~~~~~~~~

--- a/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts
+++ b/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -18,15 +18,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedRequiredField.invalid.ts
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedRequiredField.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedRequiredField.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedRequiredField.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithDescription.ts
+++ b/src/tests/fixtures/input_types/InputTypeWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -18,15 +18,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts
+++ b/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -16,15 +16,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/input_types/RenamedInputType.ts
+++ b/src/tests/fixtures/input_types/RenamedInputType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/input_types/RenamedInputType.ts.expected
+++ b/src/tests/fixtures/input_types/RenamedInputType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-class Query {
+class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -15,15 +15,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }
 

--- a/src/tests/fixtures/interfaces/FieldReturnsInterface.ts
+++ b/src/tests/fixtures/interfaces/FieldReturnsInterface.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): IPerson {
     return new User();

--- a/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): IPerson {
     return new User();
@@ -25,15 +25,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Person
 }
 

--- a/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts
+++ b/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
+++ b/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -29,15 +29,11 @@ class User extends Person implements Actor {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/ImplementsInterface.ts
+++ b/src/tests/fixtures/interfaces/ImplementsInterface.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -25,15 +25,11 @@ class User implements Person {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts
+++ b/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -29,15 +29,11 @@ class User implements Person<string> {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts
+++ b/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -31,15 +31,11 @@ class User implements Person, Actor {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -28,15 +28,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -31,15 +31,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts
+++ b/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -25,15 +25,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts
+++ b/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -27,15 +27,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceWithDescription.ts
+++ b/src/tests/fixtures/interfaces/InterfaceWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();

--- a/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): User {
     return new User();
@@ -29,15 +29,11 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User
 }
 

--- a/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts
+++ b/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts
@@ -1,7 +1,7 @@
 import { ID } from "../../../types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): Node {
     throw new Error("Not implemented");

--- a/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { ID } from "../../../types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): Node {
     throw new Error("Not implemented");
@@ -24,15 +24,11 @@ interface Node {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Node
 }
 

--- a/src/tests/fixtures/interfaces/MergedInterfaces.ts
+++ b/src/tests/fixtures/interfaces/MergedInterfaces.ts
@@ -1,7 +1,7 @@
 import { ID } from "../../../types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): Node {
     throw new Error("Not implemented");

--- a/src/tests/fixtures/interfaces/MergedInterfaces.ts.expected
+++ b/src/tests/fixtures/interfaces/MergedInterfaces.ts.expected
@@ -4,7 +4,7 @@ INPUT
 import { ID } from "../../../types";
 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me(): Node {
     throw new Error("Not implemented");

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts
@@ -3,7 +3,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
@@ -6,7 +6,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;
@@ -16,14 +16,10 @@ export class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String
 }

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts
@@ -3,7 +3,7 @@ export type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
@@ -6,7 +6,7 @@ export type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;
@@ -16,14 +16,10 @@ export class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String
 }

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts
@@ -3,7 +3,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueInArgsPos.invalid.ts.expected
@@ -6,7 +6,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueMissingTypeAnnotation.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx?: SomeType): string {
     // This is fine since Grats will always pass ctx. It's fine for

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx?: SomeType): string {
     // This is fine since Grats will always pass ctx. It's fine for
@@ -17,14 +17,10 @@ type SomeType = { greeting: string };
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String
 }

--- a/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ...ctx: SomeType): string {
     return ctx[0].greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueSpread.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ...ctx: SomeType): string {
     return ctx[0].greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: ThisIsNeverDefined): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypeNotDefined.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: ThisIsNeverDefined): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: any): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsAny.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: any): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: { greeting: string }): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsLiteral.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: { greeting: string }): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: never): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsNever.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: never): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: string): string {
     return ctx;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsString.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: string): string {
     return ctx;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: unknown): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: unknown): string {
     return ctx.greeting;
@@ -12,14 +12,10 @@ export class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String
 }

--- a/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts
+++ b/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts
@@ -3,7 +3,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
@@ -6,7 +6,7 @@ type GratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;
@@ -21,15 +21,11 @@ export class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String
   alsoGreeting: String
 }

--- a/src/tests/fixtures/resolver_context/MultipleContextValuesUsed.invalid.ts
+++ b/src/tests/fixtures/resolver_context/MultipleContextValuesUsed.invalid.ts
@@ -7,7 +7,7 @@ type AlsoGratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/resolver_context/MultipleContextValuesUsed.invalid.ts.expected
+++ b/src/tests/fixtures/resolver_context/MultipleContextValuesUsed.invalid.ts.expected
@@ -10,7 +10,7 @@ type AlsoGratsContext = {
 };
 
 /** @gqlType */
-export class Query {
+export class SomeType {
   /** @gqlField */
   greeting(args: unknown, ctx: GratsContext): string {
     return ctx.greeting;

--- a/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts
+++ b/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }

--- a/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: MyEnum;
 }
@@ -17,15 +17,11 @@ type MyEnum =
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: MyEnum
 }
 

--- a/src/tests/fixtures/todo/userExample.ts
+++ b/src/tests/fixtures/todo/userExample.ts
@@ -1,8 +1,8 @@
 /** @gqlType */
-type Query = {};
+type SomeType = {};
 
 /** @gqlField */
-export function me(_: Query): User {
+export function me(_: SomeType): User {
   return { firstName: "John", lastName: "Doe" };
 }
 

--- a/src/tests/fixtures/todo/userExample.ts.expected
+++ b/src/tests/fixtures/todo/userExample.ts.expected
@@ -2,10 +2,10 @@
 INPUT
 ----------------- 
 /** @gqlType */
-type Query = {};
+type SomeType = {};
 
 /** @gqlField */
-export function me(_: Query): User {
+export function me(_: SomeType): User {
   return { firstName: "John", lastName: "Doe" };
 }
 
@@ -25,15 +25,11 @@ export function fullName(user: User): string {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: User @exported(filename: "tests/fixtures/todo/userExample.js", functionName: "me")
 }
 

--- a/src/tests/fixtures/type_definitions/ClassWithDescription.ts
+++ b/src/tests/fixtures/type_definitions/ClassWithDescription.ts
@@ -3,7 +3,7 @@
  *
  * @gqlType
  */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
@@ -6,7 +6,7 @@ INPUT
  *
  * @gqlType
  */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -14,15 +14,11 @@ export default class Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts
+++ b/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts
@@ -1,7 +1,7 @@
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default class NotQuery {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
@@ -4,7 +4,7 @@ INPUT
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default class NotQuery {
   /** @gqlField */
@@ -14,15 +14,11 @@ export default class NotQuery {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions/RenamedType.ts
+++ b/src/tests/fixtures/type_definitions/RenamedType.ts
@@ -1,5 +1,5 @@
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 class MyClass {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 class MyClass {
   /** @gqlField */
@@ -14,14 +14,10 @@ class MyClass {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions/RenamedTypeWithoutClassName.invalid.ts
+++ b/src/tests/fixtures/type_definitions/RenamedTypeWithoutClassName.invalid.ts
@@ -1,5 +1,5 @@
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default class {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions/RenamedTypeWithoutClassName.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedTypeWithoutClassName.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default class {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts
@@ -1,4 +1,4 @@
 /** @gqlType */
-export type Query = {
+export type SomeType = {
   hello: string;
 }[];

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts.expected
@@ -2,17 +2,17 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export type Query = {
+export type SomeType = {
   hello: string;
 }[];
 
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
+src/tests/fixtures/type_definitions_from_alias/AliasIsArrayNotLiteral.invalid.ts:2:24 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
 
-2 export type Query = {
-                      ~
+2 export type SomeType = {
+                         ~
 3   hello: string;
   ~~~~~~~~~~~~~~~~
 4 }[];

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts
@@ -1,2 +1,2 @@
 /** @gqlType */
-export type Query = 10;
+export type SomeType = 10;

--- a/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts.expected
@@ -2,12 +2,12 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export type Query = 10;
+export type SomeType = 10;
 
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts:2:21 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
+src/tests/fixtures/type_definitions_from_alias/AliasIsNumberNotLiteral.invalid.ts:2:24 - error: Expected `@gqlType` type to be a type literal or `unknown`. For example: `type Foo = { bar: string }` or `type Query = unknown`.
 
-2 export type Query = 10;
-                      ~~
+2 export type SomeType = 10;
+                         ~~

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts
@@ -1,7 +1,7 @@
 /** @gqlType */
-export type Query = unknown;
+export type SomeType = unknown;
 
 /** @gqlField */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world";
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -2,24 +2,20 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export type Query = unknown;
+export type SomeType = unknown;
 
 /** @gqlField */
-export function greeting(_: Query): string {
+export function greeting(_: SomeType): string {
   return "Hello world";
 }
 
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   greeting: String @exported(filename: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", functionName: "greeting")
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasType.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export type Query = {
+export type SomeType = {
   /** @gqlField */
   hello: string;
 };

--- a/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export type Query = {
+export type SomeType = {
   /** @gqlField */
   hello: string;
 };
@@ -10,14 +10,10 @@ export type Query = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts
@@ -3,7 +3,7 @@
  *
  * @gqlType
  */
-export type Query = {
+export type SomeType = {
   /** @gqlField */
   hello: string;
 };

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
@@ -6,7 +6,7 @@ INPUT
  *
  * @gqlType
  */
-export type Query = {
+export type SomeType = {
   /** @gqlField */
   hello: string;
 };
@@ -14,15 +14,11 @@ export type Query = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts
@@ -1,7 +1,7 @@
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export type NotQuery = {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
@@ -4,7 +4,7 @@ INPUT
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export type NotQuery = {
   /** @gqlField */
@@ -14,15 +14,11 @@ export type NotQuery = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts
+++ b/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts
@@ -1,5 +1,5 @@
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 type MyAlias = {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 type MyAlias = {
   /** @gqlField */
@@ -12,14 +12,10 @@ type MyAlias = {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default interface Query {
+export default interface SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default interface Query {
+export default interface SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -10,14 +10,10 @@ export default interface Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts
@@ -3,7 +3,7 @@
  *
  * @gqlType
  */
-export default interface Query {
+export default interface SomeType {
   /** @gqlField */
   hello: string;
 }

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
@@ -6,7 +6,7 @@ INPUT
  *
  * @gqlType
  */
-export default interface Query {
+export default interface SomeType {
   /** @gqlField */
   hello: string;
 }
@@ -14,15 +14,11 @@ export default interface Query {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts
@@ -1,7 +1,7 @@
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default interface NotQuery {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
@@ -4,7 +4,7 @@ INPUT
 /**
  * The root of all evil.
  *
- * @gqlType Query
+ * @gqlType SomeType
  */
 export default interface NotQuery {
   /** @gqlField */
@@ -14,15 +14,11 @@ export default interface NotQuery {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts
+++ b/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts
@@ -1,5 +1,5 @@
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 interface MyInterface {
   /** @gqlField */

--- a/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /**
- * @gqlType Query
+ * @gqlType SomeType
  */
 interface MyInterface {
   /** @gqlField */
@@ -12,14 +12,10 @@ interface MyInterface {
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   hello: String
 }

--- a/src/tests/fixtures/unions/DefineUnionType.ts
+++ b/src/tests/fixtures/unions/DefineUnionType.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionType.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionType.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }
@@ -27,15 +27,11 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Actor
 }
 

--- a/src/tests/fixtures/unions/DefineUnionTypeContainingInterface.invalid.ts
+++ b/src/tests/fixtures/unions/DefineUnionTypeContainingInterface.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeContainingInterface.invalid.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeContainingInterface.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeReferencingInputType.invalid.ts
+++ b/src/tests/fixtures/unions/DefineUnionTypeReferencingInputType.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeReferencingInputType.invalid.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeReferencingInputType.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeReferencingLiteral.invalid.ts
+++ b/src/tests/fixtures/unions/DefineUnionTypeReferencingLiteral.invalid.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeReferencingLiteral.invalid.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeReferencingLiteral.invalid.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }
@@ -27,15 +27,11 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Actor
 }
 

--- a/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }
@@ -27,15 +27,11 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Actor
 }
 

--- a/src/tests/fixtures/unions/UnionWithDescription.ts
+++ b/src/tests/fixtures/unions/UnionWithDescription.ts
@@ -1,5 +1,5 @@
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }

--- a/src/tests/fixtures/unions/UnionWithDescription.ts.expected
+++ b/src/tests/fixtures/unions/UnionWithDescription.ts.expected
@@ -2,7 +2,7 @@
 INPUT
 ----------------- 
 /** @gqlType */
-export default class Query {
+export default class SomeType {
   /** @gqlField */
   me: Actor;
 }
@@ -30,15 +30,11 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
-schema {
-  query: Query
-}
-
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
 
-type Query {
+type SomeType {
   me: Actor
 }
 


### PR DESCRIPTION
This should make it easier to change how operations work without having tons of thrash in those PRs.