### PR TITLE
Support subscriptions

### DIFF
--- a/examples/apollo-server/schema.graphql
+++ b/examples/apollo-server/schema.graphql
@@ -2,6 +2,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/esbuild-register/schema.graphql
+++ b/examples/esbuild-register/schema.graphql
@@ -2,6 +2,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/express-graphql-http-functions/dist/schema.graphql
+++ b/examples/express-graphql-http-functions/dist/schema.graphql
@@ -3,6 +3,8 @@ schema {
   mutation: Mutation
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/express-graphql-http/schema.graphql
+++ b/examples/express-graphql-http/schema.graphql
@@ -2,6 +2,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/express-graphql/schema.graphql
+++ b/examples/express-graphql/schema.graphql
@@ -2,6 +2,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/ts-node/schema.graphql
+++ b/examples/ts-node/schema.graphql
@@ -2,6 +2,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION

--- a/examples/yoga/README.md
+++ b/examples/yoga/README.md
@@ -1,7 +1,8 @@
 # Grats + Yoga + node:http
 
-Simple demo project integrating [Grats](https://grats.capt.dev/) and [Yoga](https://github.com/dotansimha/graphql-yoga) with Node's built-in HTTP server.
+Simple demo project integrating [Grats](https://grats.capt.dev/) and [Yoga](https://github.com/dotansimha/graphql-yoga) with Node's built-in HTTP server. This example also includes an working example of GraphQL subscriptions.
 
 ## Running the demo
-* `$ pnpm install`
-* `$ pnpm run start`
+
+- `$ pnpm install`
+- `$ pnpm run start`

--- a/examples/yoga/Subscription.ts
+++ b/examples/yoga/Subscription.ts
@@ -7,7 +7,7 @@ export type Subscription = unknown;
 export async function* countdown(
   _: Subscription,
   args: { from: Int },
-): AsyncGenerator<Int> {
+): AsyncIterable<Int> {
   for (let i = args.from; i >= 0; i--) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     yield i;

--- a/examples/yoga/Subscription.ts
+++ b/examples/yoga/Subscription.ts
@@ -1,0 +1,15 @@
+import { Int } from "grats";
+
+/** @gqlType */
+export type Subscription = unknown;
+
+/** @gqlField */
+export async function* countdown(
+  _: Subscription,
+  args: { from: Int },
+): AsyncGenerator<Int> {
+  for (let i = args.from; i >= 0; i--) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    yield i;
+  }
+}

--- a/examples/yoga/package.json
+++ b/examples/yoga/package.json
@@ -16,7 +16,8 @@
     "grats",
     "yoga",
     "javascript",
-    "typescript"
+    "typescript",
+    "subscriptions"
   ],
   "author": "",
   "license": "ISC",

--- a/examples/yoga/schema.graphql
+++ b/examples/yoga/schema.graphql
@@ -1,6 +1,9 @@
 schema {
   query: Query
+  subscription: Subscription
 }
+
+directive @asyncIterable on FIELD_DEFINITION
 
 directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
@@ -20,6 +23,10 @@ type Query {
   allUsers: [User!]! @exported(jsModulePath: "examples/yoga/dist/models/User.js", tsModulePath: "examples/yoga/models/User.ts", functionName: "allUsers")
   me: User! @exported(jsModulePath: "examples/yoga/dist/Query.js", tsModulePath: "examples/yoga/Query.ts", functionName: "me")
   person: IPerson! @exported(jsModulePath: "examples/yoga/dist/Query.js", tsModulePath: "examples/yoga/Query.ts", functionName: "person")
+}
+
+type Subscription {
+  countdown(from: Int!): Int! @exported(jsModulePath: "examples/yoga/dist/Subscription.js", tsModulePath: "examples/yoga/Subscription.ts", functionName: "countdown") @asyncIterable
 }
 
 type User implements IPerson {

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -360,3 +360,11 @@ export function graphQLNameHasLeadingNewlines(
 export function graphQLTagNameHasWhitespace(tagName: string): string {
   return `Expected text following a \`@${tagName}\` tag to be a GraphQL name. If you intended this text to be a description, place it at the top of the docblock before any \`@tags\`.`;
 }
+
+export function subscriptionFieldNotAsyncIterable() {
+  return "Expected fields on `Subscription` to return an AsyncIterable.";
+}
+
+export function nonSubscriptionFieldAsyncIterable() {
+  return "Unexpected AsyncIterable. Only fields on `Subscription` should return an AsyncIterable.";
+}

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -32,6 +32,7 @@ import * as E from "./Errors";
 import { traverseJSDocTags } from "./utils/JSDoc";
 import { GraphQLConstructor } from "./GraphQLConstructor";
 import {
+  ASYNC_ITERABLE_TYPE_DIRECTIVE,
   EXPORTED_DIRECTIVE,
   EXPORTED_FUNCTION_NAME_ARG,
   JS_MODULE_PATH_ARG,
@@ -384,9 +385,9 @@ export class Extractor {
     if (isStream) {
       directives.push(
         this.gql.constDirective(
-          tag,
-          this.gql.name(node.type, "asyncIterable"),
-          [],
+          node.type,
+          this.gql.name(node.type, ASYNC_ITERABLE_TYPE_DIRECTIVE),
+          null,
         ),
       );
     }
@@ -1456,9 +1457,9 @@ export class Extractor {
     if (isStream) {
       directives.push(
         this.gql.constDirective(
-          tag,
-          this.gql.name(node.type, "asyncIterable"),
-          [],
+          node.type,
+          this.gql.name(node.type, ASYNC_ITERABLE_TYPE_DIRECTIVE),
+          null,
         ),
       );
     }
@@ -1484,7 +1485,7 @@ export class Extractor {
     if (ts.isTypeReferenceNode(node)) {
       const identifier = this.expectIdentifier(node.typeName);
       if (identifier == null) return null;
-      if (identifier.text == "AsyncGenerator") {
+      if (identifier.text == "AsyncIterable") {
         if (node.typeArguments == null || node.typeArguments.length === 0) {
           // TODO: Better error?
           return this.report(node, E.promiseMissingTypeArg());
@@ -1729,7 +1730,7 @@ export class Extractor {
   }
 
   // It is a GraphQL best practice to model all fields as nullable. This allows
-  // the server to handle field level exections by simply returning null for
+  // the server to handle field level executions by simply returning null for
   // that field.
   // https://graphql.org/learn/best-practices/#nullability
   handleErrorBubbling(parentNode: ts.Node, type: TypeNode) {

--- a/src/TypeContext.ts
+++ b/src/TypeContext.ts
@@ -163,6 +163,7 @@ export class TypeContext {
     return ok(newDoc);
   }
 
+  // TODO: Is this still used?
   handleAbstractDefinitions(
     docs: GratsDefinitionNode[],
   ): DiagnosticsResult<DefinitionNode[]> {

--- a/src/TypeContext.ts
+++ b/src/TypeContext.ts
@@ -2,9 +2,13 @@ import {
   DefinitionNode,
   DocumentNode,
   FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  InterfaceTypeExtensionNode,
   Kind,
   Location,
   NameNode,
+  ObjectTypeDefinitionNode,
+  ObjectTypeExtensionNode,
   visit,
 } from "graphql";
 import * as ts from "typescript";
@@ -16,7 +20,10 @@ import {
   ok,
 } from "./utils/DiagnosticError";
 import { getRelativeOutputPath } from "./gratsRoot";
-import { EXPORTED_DIRECTIVE } from "./serverDirectives";
+import {
+  ASYNC_ITERABLE_TYPE_DIRECTIVE as ASYNC_GENERATOR_DIRECTIVE,
+  EXPORTED_DIRECTIVE,
+} from "./serverDirectives";
 import { FIELD_TAG } from "./Extractor";
 import * as E from "./Errors";
 import { InterfaceMap, computeInterfaceMap } from "./InterfaceGraph";
@@ -161,6 +168,73 @@ export class TypeContext {
       return err(errors);
     }
     return ok(newDoc);
+  }
+
+  // Ensure that all fields on `Subscription` return an AsyncIterable, and that no other
+  // fields do.
+  validateAsyncIterableFields(doc: DocumentNode): DiagnosticsResult<void> {
+    const errors: ts.Diagnostic[] = [];
+
+    const visitNode = (
+      t:
+        | ObjectTypeDefinitionNode
+        | ObjectTypeExtensionNode
+        | InterfaceTypeDefinitionNode
+        | InterfaceTypeExtensionNode,
+    ) => {
+      const validateFieldsResult = this.validateField(t);
+      if (validateFieldsResult != null) {
+        errors.push(validateFieldsResult);
+      }
+    };
+
+    visit(doc, {
+      [Kind.INTERFACE_TYPE_DEFINITION]: visitNode,
+      [Kind.INTERFACE_TYPE_EXTENSION]: visitNode,
+      [Kind.OBJECT_TYPE_DEFINITION]: visitNode,
+      [Kind.OBJECT_TYPE_EXTENSION]: visitNode,
+    });
+    if (errors.length > 0) {
+      return err(errors);
+    }
+    return ok(undefined);
+  }
+  validateField(
+    t:
+      | ObjectTypeDefinitionNode
+      | ObjectTypeExtensionNode
+      | InterfaceTypeDefinitionNode
+      | InterfaceTypeExtensionNode,
+  ): ts.Diagnostic | void {
+    if (t.fields == null) return;
+    // Note: We assume the default name is used here. When custom operation types are supported
+    // we'll need to update this.
+    const isSubscription =
+      t.name.value === "Subscription" &&
+      (t.kind === Kind.OBJECT_TYPE_DEFINITION ||
+        t.kind === Kind.OBJECT_TYPE_EXTENSION);
+    for (const field of t.fields) {
+      const asyncDirective = field.directives?.find(
+        (directive) => directive.name.value === ASYNC_GENERATOR_DIRECTIVE,
+      );
+
+      if (isSubscription && asyncDirective == null) {
+        if (field.type.loc == null) {
+          throw new Error("Expected field type to have a location.");
+        }
+        return this.err(field.type.loc, E.subscriptionFieldNotAsyncIterable());
+      }
+
+      if (!isSubscription && asyncDirective != null) {
+        if (asyncDirective.loc == null) {
+          throw new Error("Expected asyncDirective to have a location.");
+        }
+        return this.err(
+          asyncDirective.loc, // Directive location is the AsyncIterable type.
+          E.nonSubscriptionFieldAsyncIterable(),
+        );
+      }
+    }
   }
 
   // TODO: Is this still used?
@@ -352,10 +426,6 @@ export class TypeContext {
       start: loc.start,
       length: loc.end - loc.start,
     };
-  }
-
-  validateInterfaceImplementorsHaveTypenameField(): DiagnosticResult<null> {
-    return ok(null);
   }
 
   getDestFilePath(sourceFile: ts.SourceFile): {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -153,6 +153,11 @@ function extractSchema(
 
   const doc = docResult.value;
 
+  const subscriptionsValidationResult = ctx.validateAsyncIterableFields(doc);
+  if (subscriptionsValidationResult.kind === "ERROR") {
+    return subscriptionsValidationResult;
+  }
+
   // TODO: Currently this does not detect definitions that shadow builtins
   // (`String`, `Int`, etc). However, if we pass a second param (extending an
   // existing schema) we do! So, we should find a way to validate that we don't

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -15,8 +15,10 @@ export const EXPORTED_DIRECTIVE = "exported";
 export const JS_MODULE_PATH_ARG = "jsModulePath";
 export const TS_MODULE_PATH_ARG = "tsModulePath";
 export const EXPORTED_FUNCTION_NAME_ARG = "functionName";
+export const ASYNC_ITERABLE_DIRECTIVE = "asyncIterable";
 
 export const DIRECTIVES_AST: DocumentNode = parse(`
+    directive @${ASYNC_ITERABLE_DIRECTIVE} on FIELD_DEFINITION
     directive @${METHOD_NAME_DIRECTIVE}(${METHOD_NAME_ARG}: String!) on FIELD_DEFINITION
     directive @${EXPORTED_DIRECTIVE}(
       ${JS_MODULE_PATH_ARG}: String!,
@@ -57,6 +59,20 @@ export function applyServerDirectives(schema: GraphQLSchema): GraphQLSchema {
           newFieldConfig,
           exportedDirective,
         );
+      }
+
+      const asyncIterableDirective = getDirective(
+        schema,
+        fieldConfig,
+        ASYNC_ITERABLE_DIRECTIVE,
+      )?.[0];
+
+      if (asyncIterableDirective != null) {
+        newFieldConfig = {
+          ...newFieldConfig,
+          subscribe: newFieldConfig.resolve,
+          resolve: (payload) => payload,
+        };
       }
 
       return newFieldConfig;

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -15,10 +15,10 @@ export const EXPORTED_DIRECTIVE = "exported";
 export const JS_MODULE_PATH_ARG = "jsModulePath";
 export const TS_MODULE_PATH_ARG = "tsModulePath";
 export const EXPORTED_FUNCTION_NAME_ARG = "functionName";
-export const ASYNC_ITERABLE_DIRECTIVE = "asyncIterable";
+export const ASYNC_ITERABLE_TYPE_DIRECTIVE = "asyncIterable";
 
 export const DIRECTIVES_AST: DocumentNode = parse(`
-    directive @${ASYNC_ITERABLE_DIRECTIVE} on FIELD_DEFINITION
+    directive @${ASYNC_ITERABLE_TYPE_DIRECTIVE} on FIELD_DEFINITION
     directive @${METHOD_NAME_DIRECTIVE}(${METHOD_NAME_ARG}: String!) on FIELD_DEFINITION
     directive @${EXPORTED_DIRECTIVE}(
       ${JS_MODULE_PATH_ARG}: String!,
@@ -64,7 +64,7 @@ export function applyServerDirectives(schema: GraphQLSchema): GraphQLSchema {
       const asyncIterableDirective = getDirective(
         schema,
         fieldConfig,
-        ASYNC_ITERABLE_DIRECTIVE,
+        ASYNC_ITERABLE_TYPE_DIRECTIVE,
       )?.[0];
 
       if (asyncIterableDirective != null) {

--- a/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
+++ b/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
+++ b/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
+++ b/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
@@ -17,6 +17,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
+++ b/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
@@ -13,6 +13,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/NullableArgument.ts.expected
+++ b/src/tests/fixtures/arguments/NullableArgument.ts.expected
@@ -32,6 +32,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/OptionalArgument.ts.expected
+++ b/src/tests/fixtures/arguments/OptionalArgument.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/arguments/StringArgument.ts.expected
+++ b/src/tests/fixtures/arguments/StringArgument.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/built_in_scalars/IdField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IdField.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/built_in_scalars/IntField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IntField.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
@@ -13,6 +13,8 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
@@ -16,6 +16,8 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
@@ -13,6 +13,8 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
@@ -19,6 +19,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
@@ -18,6 +18,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
@@ -18,6 +18,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
@@ -24,6 +24,8 @@ type ConnectionInput = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
@@ -30,6 +30,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
@@ -17,6 +17,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
@@ -17,6 +17,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
+++ b/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
@@ -21,6 +21,8 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/Enum.ts.expected
+++ b/src/tests/fixtures/enums/Enum.ts.expected
@@ -16,6 +16,8 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
@@ -13,6 +13,8 @@ type MyEnum = "VALID" | "INVALID";
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
@@ -16,6 +16,8 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
@@ -18,6 +18,8 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
@@ -18,6 +18,8 @@ type MyEnum = Valid | Invalid;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
@@ -13,6 +13,8 @@ type MyEnum = "VALID";
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
@@ -16,6 +16,8 @@ type MyEnum = "VALID" | "INVALID";
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
+++ b/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
@@ -16,6 +16,8 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithDescription.ts.expected
@@ -20,6 +20,8 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
@@ -18,6 +18,8 @@ enum Enum {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/examples/playground.ts.expected
+++ b/src/tests/fixtures/examples/playground.ts.expected
@@ -38,6 +38,8 @@ export function getUser(_: SomeType): UserResolver {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/examples/readme.ts.expected
+++ b/src/tests/fixtures/examples/readme.ts.expected
@@ -37,6 +37,8 @@ schema {
   query: Query
 }
 
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
@@ -32,6 +32,8 @@ class Admin implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
@@ -37,6 +37,8 @@ class Admin implements IPerson, IThing {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
@@ -17,6 +17,8 @@ export function greeting(query: SomeType): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
@@ -14,6 +14,8 @@ export function greeting(_: SomeType, args: { name: string }): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
@@ -17,6 +17,8 @@ export function greeting(_: SomeType): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -14,6 +14,8 @@ export function greeting(_: SomeType): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
@@ -14,6 +14,8 @@ export function greeting(_: SomeType): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
+++ b/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
@@ -21,6 +21,8 @@ export function greeting(iFoo: IFoo): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/extend_type/optionalModelType.ts.expected
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts.expected
@@ -21,6 +21,8 @@ export function greeting(
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
@@ -13,6 +13,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/MethodSignatureOnInterface.ts.expected
+++ b/src/tests/fixtures/field_definitions/MethodSignatureOnInterface.ts.expected
@@ -10,6 +10,8 @@ interface ICarly {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/RenamedField.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedField.ts.expected
@@ -15,6 +15,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
@@ -23,6 +23,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/ArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
+++ b/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/BooleanField.ts.expected
+++ b/src/tests/fixtures/field_values/BooleanField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/CustomScalar.ts.expected
+++ b/src/tests/fixtures/field_values/CustomScalar.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/KitchenSink.ts.expected
+++ b/src/tests/fixtures/field_values/KitchenSink.ts.expected
@@ -61,6 +61,8 @@ class Group {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/LinkedField.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedField.ts.expected
@@ -24,6 +24,8 @@ class User {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
@@ -26,6 +26,8 @@ class User<T> {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/OptionalFields.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalFields.ts.expected
@@ -24,6 +24,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/OptionalProperty.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalProperty.ts.expected
@@ -10,6 +10,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
+++ b/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/RenamedType.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedType.ts.expected
@@ -16,6 +16,8 @@ class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
@@ -16,6 +16,8 @@ class UserResolver {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/StringField.ts.expected
+++ b/src/tests/fixtures/field_values/StringField.ts.expected
@@ -12,6 +12,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
@@ -15,6 +15,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/UnionField.ts.expected
+++ b/src/tests/fixtures/field_values/UnionField.ts.expected
@@ -29,6 +29,8 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
@@ -13,6 +13,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
@@ -13,6 +13,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/InputType.ts.expected
+++ b/src/tests/fixtures/input_types/InputType.ts.expected
@@ -15,6 +15,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
@@ -15,6 +15,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
@@ -18,6 +18,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
@@ -18,6 +18,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
@@ -16,6 +16,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/input_types/RenamedInputType.ts.expected
+++ b/src/tests/fixtures/input_types/RenamedInputType.ts.expected
@@ -15,6 +15,8 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
@@ -25,6 +25,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
+++ b/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
@@ -29,6 +29,8 @@ class User extends Person implements Actor {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
@@ -25,6 +25,8 @@ class User implements Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
@@ -29,6 +29,8 @@ class User implements Person<string> {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
@@ -31,6 +31,8 @@ class User implements Person, Actor {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/ImplementsRenamedInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsRenamedInterface.ts.expected
@@ -17,6 +17,8 @@ class User implements DONT_USE_THIS {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceDefinitionExtendsGqlInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceDefinitionExtendsGqlInterface.ts.expected
@@ -32,6 +32,8 @@ export interface User extends Mammal, Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceExtendsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceExtendsInterface.ts.expected
@@ -24,6 +24,8 @@ interface Actor extends GqlNode, Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
@@ -28,6 +28,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
@@ -31,6 +31,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceImplementsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceImplementsInterface.ts.expected
@@ -24,6 +24,8 @@ interface Actor extends GqlNode, Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
@@ -25,6 +25,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
@@ -27,6 +27,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
@@ -29,6 +29,8 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
@@ -24,6 +24,8 @@ interface Node {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/interfaces/extendInterfaceWithNonGqlType.ts.expected
+++ b/src/tests/fixtures/interfaces/extendInterfaceWithNonGqlType.ts.expected
@@ -16,6 +16,8 @@ export interface IPerson extends IThing {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
@@ -16,6 +16,8 @@ export class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
@@ -16,6 +16,8 @@ export class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
@@ -17,6 +17,8 @@ type SomeType = { greeting: string };
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
@@ -12,6 +12,8 @@ export class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
@@ -16,6 +16,8 @@ export function greeting(_: User, args: unknown, ctx: GratsContext): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
@@ -21,6 +21,8 @@ export class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/subscriptions/InputTypeWithAsyncIterable.invalid.ts
+++ b/src/tests/fixtures/subscriptions/InputTypeWithAsyncIterable.invalid.ts
@@ -1,0 +1,5 @@
+/** @gqlInput */
+export type NotSubscription = {
+  /** @gqlField */
+  greetings: AsyncIterable<string>;
+};

--- a/src/tests/fixtures/subscriptions/InputTypeWithAsyncIterable.invalid.ts.expected
+++ b/src/tests/fixtures/subscriptions/InputTypeWithAsyncIterable.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlInput */
+export type NotSubscription = {
+  /** @gqlField */
+  greetings: AsyncIterable<string>;
+};
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/subscriptions/InputTypeWithAsyncIterable.invalid.ts:4:14 - error: This type is not a valid GraphQL type. Did you mean to annotate it's definition with a `/** @gql */` tag such as `/** @gqlType */` or `/** @gqlInput **/`?
+
+4   greetings: AsyncIterable<string>;
+               ~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/subscriptions/InterfaceWithAsyncIterable.invalid.ts
+++ b/src/tests/fixtures/subscriptions/InterfaceWithAsyncIterable.invalid.ts
@@ -1,0 +1,5 @@
+/** @gqlInterface */
+export interface NotSubscription {
+  /** @gqlField */
+  greetings(): AsyncIterable<string>;
+}

--- a/src/tests/fixtures/subscriptions/InterfaceWithAsyncIterable.invalid.ts.expected
+++ b/src/tests/fixtures/subscriptions/InterfaceWithAsyncIterable.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlInterface */
+export interface NotSubscription {
+  /** @gqlField */
+  greetings(): AsyncIterable<string>;
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/subscriptions/InterfaceWithAsyncIterable.invalid.ts:4:16 - error: Unexpected AsyncIterable. Only fields on `Subscription` should return an AsyncIterable.
+
+4   greetings(): AsyncIterable<string>;
+                 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/subscriptions/NonSubscriptionClassWithAsyncIterable.invalid.ts
+++ b/src/tests/fixtures/subscriptions/NonSubscriptionClassWithAsyncIterable.invalid.ts
@@ -1,0 +1,8 @@
+/** @gqlType */
+export class User {
+  /** @gqlField */
+  async *greetings(): AsyncIterable<string> {
+    yield "Hello";
+    yield "World";
+  }
+}

--- a/src/tests/fixtures/subscriptions/NonSubscriptionClassWithAsyncIterable.invalid.ts.expected
+++ b/src/tests/fixtures/subscriptions/NonSubscriptionClassWithAsyncIterable.invalid.ts.expected
@@ -1,0 +1,19 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class User {
+  /** @gqlField */
+  async *greetings(): AsyncIterable<string> {
+    yield "Hello";
+    yield "World";
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/subscriptions/NonSubscriptionClassWithAsyncIterable.invalid.ts:4:23 - error: Unexpected AsyncIterable. Only fields on `Subscription` should return an AsyncIterable.
+
+4   async *greetings(): AsyncIterable<string> {
+                        ~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/subscriptions/SubscriptionClassWithAsyncIterable.ts
+++ b/src/tests/fixtures/subscriptions/SubscriptionClassWithAsyncIterable.ts
@@ -1,0 +1,8 @@
+/** @gqlType */
+export class Subscription {
+  /** @gqlField */
+  async *greetings(): AsyncIterable<string> {
+    yield "Hello";
+    yield "World";
+  }
+}

--- a/src/tests/fixtures/subscriptions/SubscriptionClassWithAsyncIterable.ts.expected
+++ b/src/tests/fixtures/subscriptions/SubscriptionClassWithAsyncIterable.ts.expected
@@ -1,0 +1,28 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export class Subscription {
+  /** @gqlField */
+  async *greetings(): AsyncIterable<string> {
+    yield "Hello";
+    yield "World";
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  subscription: Subscription
+}
+
+directive @asyncIterable on FIELD_DEFINITION
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
+
+type Subscription {
+  greetings: String @asyncIterable
+}

--- a/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts
+++ b/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts
@@ -1,0 +1,8 @@
+/** @gqlType */
+export type Subscription = {};
+
+/** @gqlField */
+export async function* greetings(_: Subscription): AsyncIterable<string> {
+  yield "Hello";
+  yield "World";
+}

--- a/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
+++ b/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
@@ -1,0 +1,28 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+export type Subscription = {};
+
+/** @gqlField */
+export async function* greetings(_: Subscription): AsyncIterable<string> {
+  yield "Hello";
+  yield "World";
+}
+
+-----------------
+OUTPUT
+-----------------
+schema {
+  subscription: Subscription
+}
+
+directive @asyncIterable on FIELD_DEFINITION
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
+
+type Subscription {
+  greetings: String @exported(jsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.js", tsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts", functionName: "greetings") @asyncIterable
+}

--- a/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
@@ -17,6 +17,8 @@ type MyEnum =
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/todo/RedefineBuiltinScalar.invalid.ts.expected
+++ b/src/tests/fixtures/todo/RedefineBuiltinScalar.invalid.ts.expected
@@ -7,6 +7,8 @@ type MyUrl = string;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/todo/userExample.ts.expected
+++ b/src/tests/fixtures/todo/userExample.ts.expected
@@ -25,6 +25,8 @@ export function fullName(user: User): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/ClassImplementsNonGqlInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassImplementsNonGqlInterface.ts.expected
@@ -17,6 +17,8 @@ interface IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
@@ -14,6 +14,8 @@ export default class SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
@@ -14,6 +14,8 @@ export default class NotQuery {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedType.ts.expected
@@ -14,6 +14,8 @@ class MyClass {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterface.ts.expected
@@ -17,6 +17,8 @@ export default class User implements Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsMultipleInterfaces.ts.expected
+++ b/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsMultipleInterfaces.ts.expected
@@ -26,6 +26,8 @@ export default class User implements Person, GqlNode {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -12,6 +12,8 @@ export function greeting(_: SomeType): string {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
@@ -10,6 +10,8 @@ export type SomeType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
@@ -14,6 +14,8 @@ export type SomeType = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
@@ -14,6 +14,8 @@ export type NotQuery = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
@@ -12,6 +12,8 @@ type MyAlias = {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
@@ -10,6 +10,8 @@ export default interface SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterface.ts.expected
@@ -18,6 +18,8 @@ export interface User extends Person {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeImplementsInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeImplementsInterface.ts.expected
@@ -20,6 +20,8 @@ interface HasName {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
@@ -14,6 +14,8 @@ export default interface SomeType {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
@@ -14,6 +14,8 @@ export default interface NotQuery {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
@@ -12,6 +12,8 @@ interface MyInterface {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/typename/PropertySignatureTypename.ts.expected
+++ b/src/tests/fixtures/typename/PropertySignatureTypename.ts.expected
@@ -17,6 +17,8 @@ export interface IPerson {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/typename/PropertyTypename.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypename.ts.expected
@@ -11,6 +11,8 @@ export class User {
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/unions/DefineUnionType.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionType.ts.expected
@@ -27,6 +27,8 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
@@ -27,6 +27,8 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
@@ -27,6 +27,8 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/unions/UnionWithDescription.ts.expected
+++ b/src/tests/fixtures/unions/UnionWithDescription.ts.expected
@@ -30,6 +30,8 @@ type Actor = User | Entity;
 -----------------
 OUTPUT
 -----------------
+directive @asyncIterable on FIELD_DEFINITION
+
 directive @methodName(name: String!) on FIELD_DEFINITION
 
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/website/docs/05-examples/04-yoga.md
+++ b/website/docs/05-examples/04-yoga.md
@@ -1,6 +1,6 @@
 # Yoga
 
-A very minimal example of using Grats with `yoga-graphql` and Node's built in HTTP server.
+A very minimal example of using Grats with `yoga-graphql` and Node's built in HTTP server. This example also includes an working example of GraphQL subscriptions.
 
 ## Libraries used
 

--- a/website/docs/05-guides/03-subscriptions.mdx
+++ b/website/docs/05-guides/03-subscriptions.mdx
@@ -1,0 +1,14 @@
+import GratsCode from "@site/src/components/GratsCode";
+import SubscriptionExample from "!!raw-loader!./snippets/subscription-example.out";
+
+# Subscriptions
+
+Graphql-js expects subscription fields to return an `AsyncIterable`. Grats enforces this pattern by requiring that subscription fields return an `AsyncIterable<T>`. Beyond that, there is nothing special about subscriptions in Grats.
+
+## Example
+
+<GratsCode mode="both" out={SubscriptionExample} />
+
+## Working Example
+
+See our [Yoga Example Project](../05-examples/04-yoga.md) for a working example of subscriptions in Grats.

--- a/website/docs/05-guides/snippets/subscription-example.grats.ts
+++ b/website/docs/05-guides/snippets/subscription-example.grats.ts
@@ -1,0 +1,16 @@
+import { Int } from "grats";
+
+/** @gqlType */
+type Subscription = unknown;
+
+/** @gqlField */
+export async function* countdown(_: Subscription): AsyncIterable<Int> {
+  for (let i = 10; i >= 0; i--) {
+    await sleep(1);
+    yield i;
+  }
+}
+
+function sleep(s: number) {
+  return new Promise((resolve) => setTimeout(resolve, s * 1000));
+}

--- a/website/docs/05-guides/snippets/subscription-example.out
+++ b/website/docs/05-guides/snippets/subscription-example.out
@@ -1,0 +1,21 @@
+import { Int } from "grats";
+
+/** @gqlType */
+type Subscription = unknown;
+
+/** @gqlField */
+export async function* countdown(_: Subscription): AsyncIterable<Int> {
+  for (let i = 10; i >= 0; i--) {
+    await sleep(1);
+    yield i;
+  }
+}
+
+function sleep(s: number) {
+  return new Promise((resolve) => setTimeout(resolve, s * 1000));
+}
+
+=== SNIP ===
+type Subscription {
+  countdown: Int
+}

--- a/website/docs/06-faq/02-why-use-comments.md
+++ b/website/docs/06-faq/02-why-use-comments.md
@@ -1,13 +1,22 @@
 # Why Use Comments?
 
-Other [similar projects](https://typegraphql.com/) use decorators to define
-GraphQL constructs. Why doesn't Grats?
+Other similar projects use [introspection](https://strawberry.rocks) or [macros](https://github.com/graphql-rust/juniper) or [decorators](https://typegraphql.com/) to define GraphQL constructs. Why does Grats choose to use comments instead?
 
-* Decorators cannot be applied to types, so it would precude the ability to
+## Introspection
+
+Because TypeScript types are stripped at runtime, it's fundamentally impossible to use introspection to "see" the types of fields.
+
+## Macros
+
+TypeScript does not currently support macros.
+
+## Decorators
+
+- Decorators cannot be applied to types, so it would preclude the ability to
   define GraphQL constructs using types (e.g. interfaces, unions, etc).
-* Decorators cannot be applied to parameters, so it would preclude the ability
+- Decorators cannot be applied to parameters, so it would preclude the ability
   to define GraphQL constructs using parameters (e.g. field arguments).
-* Decorators are a runtime construct, which means they must be imported and give
+- Decorators are a runtime construct, which means they must be imported and give
   the impression that they might have some runtime behavior. This is not the
   case for Grats, which is purely a static analysis tool.
 

--- a/website/scripts/gratsCode.js
+++ b/website/scripts/gratsCode.js
@@ -41,7 +41,9 @@ function processFile(file) {
   const schema = schemaResult.value;
   schema._directives = schema._directives.filter(
     (directive) =>
-      directive.name !== "exported" && directive.name !== "methodName",
+      directive.name !== "exported" &&
+      directive.name !== "methodName" &&
+      directive.name !== "asyncIterable",
   );
   const graphql = printSchema(schema, {
     assumeValid: true,

--- a/website/src/components/PlaygroundFeatures/linter.ts
+++ b/website/src/components/PlaygroundFeatures/linter.ts
@@ -100,7 +100,9 @@ function computeOutput(schemaResult, view) {
     // HACK!
     schema._directives = schema._directives.filter(
       (directive) =>
-        directive.name !== "exported" && directive.name !== "methodName",
+        directive.name !== "exported" &&
+        directive.name !== "methodName" &&
+        directive.name !== "asyncIterable",
     );
     return printSchema(schema);
   }


### PR DESCRIPTION
## TODO

- [x] Documentation
- [x] Validation (require async iterables for root subscription fields, prevent their use elsewhere)
- [x] Unit tests validating above validation
- [ ] ~Integration tests for all servers that support subscriptions (all of them?)~
- [x] Consider how we feel about adding yet more directives to the schema