### PR TITLE
Improve error messages for invalid GraphQL names

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -349,3 +349,14 @@ export function unexpectedParamSpreadForContextParam() {
 export function multipleContextTypes() {
   return "Context argument's type does not match. Grats expects all resolvers that read the context argument to use the same type for that argument. Did you use the incorrect type in one of your resolvers?";
 }
+
+export function graphQLNameHasLeadingNewlines(
+  name: string,
+  tagName: string,
+): string {
+  return `Expected the GraphQL name \`${name}\` to be on the same line as it's \`@${tagName}\` tag.`;
+}
+
+export function graphQLTagNameHasWhitespace(tagName: string): string {
+  return `Expected text following a \`@${tagName}\` tag to be a GraphQL name. If you intended this text to be a description, place it at the top of the docblock before any \`@tags\`.`;
+}

--- a/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts
+++ b/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts
@@ -1,0 +1,25 @@
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * Sup
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * @gqlType
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
@@ -1,0 +1,40 @@
+-----------------
+INPUT
+----------------- 
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * Sup
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * @gqlType
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}
+
+-----------------
+OUTPUT
+-----------------
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+"""Sup"""
+type SomeType {
+  name: String
+}

--- a/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts
+++ b/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts
@@ -1,0 +1,12 @@
+/**
+ * @gqlType
+ *
+ *
+ *
+ *
+ *
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
@@ -1,0 +1,26 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType
+ *
+ *
+ *
+ *
+ *
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}
+
+-----------------
+OUTPUT
+-----------------
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+
+type SomeType {
+  name: String
+}

--- a/src/tests/fixtures/descriptions/DescriptionFollowsTypeTag.invalid.ts
+++ b/src/tests/fixtures/descriptions/DescriptionFollowsTypeTag.invalid.ts
@@ -1,0 +1,11 @@
+/**
+ * @gqlType
+ *
+ * This is a note for myself
+ */
+export type Query = unknown;
+
+/** @gqlField */
+export function queryField(_: Query): string {
+  return "";
+}

--- a/src/tests/fixtures/descriptions/DescriptionFollowsTypeTag.invalid.ts.expected
+++ b/src/tests/fixtures/descriptions/DescriptionFollowsTypeTag.invalid.ts.expected
@@ -1,0 +1,28 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType
+ *
+ * This is a note for myself
+ */
+export type Query = unknown;
+
+/** @gqlField */
+export function queryField(_: Query): string {
+  return "";
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/descriptions/DescriptionFollowsTypeTag.invalid.ts:2:4 - error: Expected text following a `@gqlType` tag to be a GraphQL name. If you intended this text to be a description, place it at the top of the docblock before any `@tags`.
+
+2  * @gqlType
+     ~~~~~~~~
+3  *
+  ~~
+4  * This is a note for myself
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5  */
+  ~

--- a/src/tests/fixtures/descriptions/DescriptionOnLineOfTypeTag.invalid.ts
+++ b/src/tests/fixtures/descriptions/DescriptionOnLineOfTypeTag.invalid.ts
@@ -1,0 +1,9 @@
+/**
+ * @gqlType This is a note for myself
+ */
+export type Query = unknown;
+
+/** @gqlField */
+export function queryField(_: Query): string {
+  return "";
+}

--- a/src/tests/fixtures/descriptions/DescriptionOnLineOfTypeTag.invalid.ts.expected
+++ b/src/tests/fixtures/descriptions/DescriptionOnLineOfTypeTag.invalid.ts.expected
@@ -1,0 +1,22 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType This is a note for myself
+ */
+export type Query = unknown;
+
+/** @gqlField */
+export function queryField(_: Query): string {
+  return "";
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/descriptions/DescriptionOnLineOfTypeTag.invalid.ts:2:4 - error: Expected text following a `@gqlType` tag to be a GraphQL name. If you intended this text to be a description, place it at the top of the docblock before any `@tags`.
+
+2  * @gqlType This is a note for myself
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+3  */
+  ~

--- a/src/tests/fixtures/descriptions/RenameFollowedByDescription.invalid.ts
+++ b/src/tests/fixtures/descriptions/RenameFollowedByDescription.invalid.ts
@@ -1,0 +1,9 @@
+/**
+ * @gqlType User
+ *
+ * The user (oops, this should go up above!)
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/descriptions/RenameFollowedByDescription.invalid.ts.expected
+++ b/src/tests/fixtures/descriptions/RenameFollowedByDescription.invalid.ts.expected
@@ -1,0 +1,26 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType User
+ *
+ * The user (oops, this should go up above!)
+ */
+class SomeType {
+  /** @gqlField */
+  name: string;
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/descriptions/RenameFollowedByDescription.invalid.ts:2:4 - error: Expected text following a `@gqlType` tag to be a GraphQL name. If you intended this text to be a description, place it at the top of the docblock before any `@tags`.
+
+2  * @gqlType User
+     ~~~~~~~~~~~~~
+3  *
+  ~~
+4  * The user (oops, this should go up above!)
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5  */
+  ~

--- a/src/tests/fixtures/type_definitions/RenamedTypeHasDash.invalid.ts
+++ b/src/tests/fixtures/type_definitions/RenamedTypeHasDash.invalid.ts
@@ -1,0 +1,9 @@
+/**
+ * @gqlType Some-Type
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}

--- a/src/tests/fixtures/type_definitions/RenamedTypeHasDash.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedTypeHasDash.invalid.ts.expected
@@ -1,0 +1,22 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType Some-Type
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/type_definitions/RenamedTypeHasDash.invalid.ts:2:4 - error: Names must only contain [_a-zA-Z0-9] but "Some-Type" does not.
+
+2  * @gqlType Some-Type
+     ~~~~~~~~~~~~~~~~~~
+3  */
+  ~

--- a/src/tests/fixtures/type_definitions/RenamedTypeNewLine.invalid.ts
+++ b/src/tests/fixtures/type_definitions/RenamedTypeNewLine.invalid.ts
@@ -1,0 +1,11 @@
+/**
+ * @gqlType
+ *
+ * SomeType
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}

--- a/src/tests/fixtures/type_definitions/RenamedTypeNewLine.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedTypeNewLine.invalid.ts.expected
@@ -1,0 +1,28 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType
+ *
+ * SomeType
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/type_definitions/RenamedTypeNewLine.invalid.ts:2:4 - error: Expected the GraphQL name `SomeType` to be on the same line as it's `@gqlType` tag.
+
+2  * @gqlType
+     ~~~~~~~~
+3  *
+  ~~
+4  * SomeType
+  ~~~~~~~~~~~
+5  */
+  ~

--- a/src/tests/fixtures/type_definitions/RenamedTypeStartsWithNumber.invalid.ts
+++ b/src/tests/fixtures/type_definitions/RenamedTypeStartsWithNumber.invalid.ts
@@ -1,0 +1,9 @@
+/**
+ * @gqlType 1SomeType
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}

--- a/src/tests/fixtures/type_definitions/RenamedTypeStartsWithNumber.invalid.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedTypeStartsWithNumber.invalid.ts.expected
@@ -1,0 +1,22 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlType 1SomeType
+ */
+class MyClass {
+  /** @gqlField */
+  hello(): string {
+    return "Hello world!";
+  }
+}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/type_definitions/RenamedTypeStartsWithNumber.invalid.ts:2:4 - error: Names must start with [_a-zA-Z] but "1SomeType" does not.
+
+2  * @gqlType 1SomeType
+     ~~~~~~~~~~~~~~~~~~
+3  */
+  ~


### PR DESCRIPTION
Fixes #50 

Playground links to the two examples in #50:

* [one](https://deploy-preview-52--grats.netlify.app/playground#N4IgJg9gxiBcIHoBUSA6A7ABEzABA5gI4A2AKgJ4AOAphtnTqQBYCWAzpu5gIaboQAXapgBmEAE6YAtuTbViIhggzUAHpQkDMAqsICKAV2rjymALyYD6ANb8A7ugDcGDMhwESAMRbyw2ZehqGuJaIlZQAiwQWIRGJt6+ABQA+rCYhsbkAJRpbALiLOj4mMB0mOLUAgbiWADktRgAviAANCBQ0SIs+HCg6AbExNwARsTUAELkACLUItwDAnD5Rm0VwQIUNADKUAWUG7oAouLiEmxL4kaNbQBuPna9IGxMEHYA4uLcAmxTLBURLBu1HOsDmxDk1xAADVDgAlLYASQA8gA5OAARkaQA)
* [two](https://deploy-preview-52--grats.netlify.app/playground#N4IgJg9gxiBcIHoBUSA6A7ABEzABA5gI4A2AKgJ4AOAphtnTqQBYCWAzgJJsCCAchABdqAMQgAnALLk21YgDMGCDNQAelcQMwCq1TAEUArtTHlMAXkwH0Aa3QQA7ugDcGDMhwESwlrLDYl6KrqYppyVlACLBBYhEYm3r4AFAD6sPpx5ACUaWwCYizo+JjAdJhi1AIGYlgA5DUYAL4gADQgUNFyLPhwoOgGxMQAhgBGxNQAQuQAItRyg-0CcHlGreXBAhQ0AMpQ+ZQbOgCiYmLibEtiRg2tAG4+9j0gbEwOAOJigwJsUyzlESw3ajnWBzYgya4gABqhwASlsOAB5XhwACMDSAA)