### PR TITLE
Fallback to importing .ts file if .js file cannot be found

### DIFF
--- a/examples/apollo-server/schema.graphql
+++ b/examples/apollo-server/schema.graphql
@@ -17,9 +17,9 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(jsModulePath: "../../examples/apollo-server/dist/models/User.js", tsModulePath: "../../examples/apollo-server/models/User.ts", functionName: "allUsers")
-  me: User! @exported(jsModulePath: "../../examples/apollo-server/dist/Query.js", tsModulePath: "../../examples/apollo-server/Query.ts", functionName: "me")
-  person: IPerson! @exported(jsModulePath: "../../examples/apollo-server/dist/Query.js", tsModulePath: "../../examples/apollo-server/Query.ts", functionName: "person")
+  allUsers: [User!]! @exported(jsModulePath: "examples/apollo-server/dist/models/User.js", tsModulePath: "examples/apollo-server/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "examples/apollo-server/dist/Query.js", tsModulePath: "examples/apollo-server/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "examples/apollo-server/dist/Query.js", tsModulePath: "examples/apollo-server/Query.ts", functionName: "person")
 }
 
 type User implements IPerson {

--- a/examples/apollo-server/schema.graphql
+++ b/examples/apollo-server/schema.graphql
@@ -2,7 +2,7 @@ schema {
   query: Query
 }
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
@@ -17,9 +17,9 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(filename: "../../examples/apollo-server/dist/models/User.js", functionName: "allUsers")
-  me: User! @exported(filename: "../../examples/apollo-server/dist/Query.js", functionName: "me")
-  person: IPerson! @exported(filename: "../../examples/apollo-server/dist/Query.js", functionName: "person")
+  allUsers: [User!]! @exported(jsModulePath: "../../examples/apollo-server/dist/models/User.js", tsModulePath: "../../examples/apollo-server/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "../../examples/apollo-server/dist/Query.js", tsModulePath: "../../examples/apollo-server/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "../../examples/apollo-server/dist/Query.js", tsModulePath: "../../examples/apollo-server/Query.ts", functionName: "person")
 }
 
 type User implements IPerson {

--- a/examples/esbuild-register/Query.ts
+++ b/examples/esbuild-register/Query.ts
@@ -1,0 +1,20 @@
+import IPerson from "./interfaces/IPerson";
+import User from "./models/User";
+
+// NOTE: Yoga does not support providing a `rootValue` to the executor. This
+// means that we cannot use a concrete value such as a class or an object
+// literal for Query or Mutation.
+//
+// Instead we use an empty type typed as `unknown`.
+
+/** @gqlType */
+export type Query = unknown;
+
+/** @gqlField */
+export function me(_: Query): User {
+  return new User();
+}
+/** @gqlField */
+export function person(_: Query): IPerson {
+  return new User();
+}

--- a/examples/esbuild-register/README.md
+++ b/examples/esbuild-register/README.md
@@ -1,0 +1,10 @@
+# Grats + esbuild-register
+
+Simple demo project integrating [Grats](https://grats.capt.dev/) and [esbuild-register](https://github.com/egoist/esbuild-register).
+
+This demonstrates Grats working with runtime TypeScript compilation. The same approach should work with similar tools like `ts-node`. See `scripts.start` in `package.json` for the relevant code.
+
+## Running the demo
+
+- `$ pnpm install`
+- `$ pnpm run start`

--- a/examples/esbuild-register/interfaces/IPerson.ts
+++ b/examples/esbuild-register/interfaces/IPerson.ts
@@ -1,0 +1,5 @@
+/** @gqlInterface */
+export default interface IPerson {
+  /** @gqlField */
+  name(): string;
+}

--- a/examples/esbuild-register/models/Group.ts
+++ b/examples/esbuild-register/models/Group.ts
@@ -1,0 +1,20 @@
+import User from "./User";
+
+/** @gqlType */
+export default class Group {
+  /** @gqlField */
+  description: string;
+
+  constructor() {
+    this.description = "A group of people";
+  }
+
+  /** @gqlField */
+  name(): string {
+    return "Pal's Club";
+  }
+  /** @gqlField */
+  async members(): Promise<User[]> {
+    return [new User()];
+  }
+}

--- a/examples/esbuild-register/models/User.ts
+++ b/examples/esbuild-register/models/User.ts
@@ -1,0 +1,21 @@
+import IPerson from "../interfaces/IPerson";
+import { Query } from "../Query";
+import Group from "./Group";
+
+/** @gqlType User */
+export default class UserResolver implements IPerson {
+  __typename = "User";
+  /** @gqlField */
+  name(): string {
+    return "Alice";
+  }
+  /** @gqlField */
+  groups(): Group[] {
+    return [new Group()];
+  }
+}
+
+/** @gqlField */
+export function allUsers(_: Query): UserResolver[] {
+  return [new UserResolver(), new UserResolver()];
+}

--- a/examples/esbuild-register/package.json
+++ b/examples/esbuild-register/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "grats-example-esbuild-register",
+  "version": "0.0.0",
+  "description": "Example server showcasing Grats used with esbuild-register",
+  "main": "index.js",
+  "scripts": {
+    "start": "node -r esbuild-register server.ts",
+    "build": ""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/captbaritone/grats.git"
+  },
+  "keywords": [
+    "graphql",
+    "grats",
+    "yoga",
+    "javascript",
+    "typescript",
+    "esbuild",
+    "esbuild-register"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/captbaritone/grats/issues"
+  },
+  "homepage": "https://github.com/captbaritone/grats#readme",
+  "dependencies": {
+    "@types/node": "^20.8.10",
+    "graphql-yoga": "^5.0.0",
+    "grats": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.19.7",
+    "esbuild-register": "^3.5.0"
+  }
+}

--- a/examples/esbuild-register/schema.graphql
+++ b/examples/esbuild-register/schema.graphql
@@ -1,0 +1,28 @@
+schema {
+  query: Query
+}
+
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+type Group {
+  description: String!
+  members: [User!]!
+  name: String!
+}
+
+interface IPerson {
+  name: String!
+}
+
+type Query {
+  allUsers: [User!]! @exported(jsModulePath: "examples/esbuild-register/dist/models/User.js", tsModulePath: "examples/esbuild-register/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "examples/esbuild-register/dist/Query.js", tsModulePath: "examples/esbuild-register/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "examples/esbuild-register/dist/Query.js", tsModulePath: "examples/esbuild-register/Query.ts", functionName: "person")
+}
+
+type User implements IPerson {
+  groups: [Group!]!
+  name: String!
+}

--- a/examples/esbuild-register/server.ts
+++ b/examples/esbuild-register/server.ts
@@ -5,8 +5,6 @@ import { createYoga } from "graphql-yoga";
 import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
 
 async function main() {
-  // FIXME: This is relative to the current working directory, not the file, or
-  // something more sensible.
   const schema = getSchema();
 
   const yoga = createYoga({

--- a/examples/esbuild-register/server.ts
+++ b/examples/esbuild-register/server.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "fs";
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+
+import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
+
+async function main() {
+  // FIXME: This is relative to the current working directory, not the file, or
+  // something more sensible.
+  const schema = getSchema();
+
+  const yoga = createYoga({
+    schema,
+  });
+
+  const server = createServer(yoga);
+
+  server.listen(4000, () => {
+    console.log(
+      "Running a GraphQL API server at http://localhost:4000/graphql",
+    );
+  });
+}
+
+function getSchema() {
+  if (process.env.FROM_SDL) {
+    console.log("Building schema from SDL...");
+    const sdl = readFileSync("./schema.graphql", "utf8");
+    return buildSchemaFromSDL(sdl);
+  }
+  console.log("Building schema from source...");
+  return extractGratsSchemaAtRuntime({
+    emitSchemaFile: "./schema.graphql",
+  });
+}
+
+main();

--- a/examples/esbuild-register/tsconfig.json
+++ b/examples/esbuild-register/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "grats": {
+    "nullableByDefault": false
+  },
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "strict": true
+  }
+}

--- a/examples/express-graphql-http-functions/dist/schema.graphql
+++ b/examples/express-graphql-http-functions/dist/schema.graphql
@@ -3,7 +3,7 @@ schema {
   mutation: Mutation
 }
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
@@ -18,16 +18,16 @@ interface IPerson {
 }
 
 type Mutation {
-  addUser(userData: UserDataInput!): User! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "addUser")
-  removeUser(id: String!): String! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "removeUser")
-  updateUser(id: String!, userData: UserDataInput!): User! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "updateUser")
+  addUser(userData: UserDataInput!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "addUser")
+  removeUser(id: String!): String! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "removeUser")
+  updateUser(id: String!, userData: UserDataInput!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "updateUser")
 }
 
 type Query {
-  allUsers: [User!]! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "allUsers")
-  me: User! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "me")
-  person: IPerson! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "person")
-  userById(id: String!): User! @exported(filename: "../../examples/express-graphql-http-functions/dist/Schema.js", functionName: "userById")
+  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "person")
+  userById(id: String!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "userById")
 }
 
 type User implements IPerson {

--- a/examples/express-graphql-http-functions/dist/schema.graphql
+++ b/examples/express-graphql-http-functions/dist/schema.graphql
@@ -18,16 +18,16 @@ interface IPerson {
 }
 
 type Mutation {
-  addUser(userData: UserDataInput!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "addUser")
-  removeUser(id: String!): String! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "removeUser")
-  updateUser(id: String!, userData: UserDataInput!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "updateUser")
+  addUser(userData: UserDataInput!): User! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "addUser")
+  removeUser(id: String!): String! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "removeUser")
+  updateUser(id: String!, userData: UserDataInput!): User! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "updateUser")
 }
 
 type Query {
-  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "allUsers")
-  me: User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "me")
-  person: IPerson! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "person")
-  userById(id: String!): User! @exported(jsModulePath: "../../examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "../../examples/express-graphql-http-functions/Schema.ts", functionName: "userById")
+  allUsers: [User!]! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "person")
+  userById(id: String!): User! @exported(jsModulePath: "examples/express-graphql-http-functions/dist/Schema.js", tsModulePath: "examples/express-graphql-http-functions/Schema.ts", functionName: "userById")
 }
 
 type User implements IPerson {

--- a/examples/express-graphql-http/schema.graphql
+++ b/examples/express-graphql-http/schema.graphql
@@ -2,7 +2,7 @@ schema {
   query: Query
 }
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
@@ -17,7 +17,7 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(filename: "../../examples/express-graphql-http/dist/models/User.js", functionName: "allUsers")
+  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql-http/dist/models/User.js", tsModulePath: "../../examples/express-graphql-http/models/User.ts", functionName: "allUsers")
   me: User!
   person: IPerson!
 }

--- a/examples/express-graphql-http/schema.graphql
+++ b/examples/express-graphql-http/schema.graphql
@@ -17,7 +17,7 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql-http/dist/models/User.js", tsModulePath: "../../examples/express-graphql-http/models/User.ts", functionName: "allUsers")
+  allUsers: [User!]! @exported(jsModulePath: "examples/express-graphql-http/dist/models/User.js", tsModulePath: "examples/express-graphql-http/models/User.ts", functionName: "allUsers")
   me: User!
   person: IPerson!
 }

--- a/examples/express-graphql-http/server.ts
+++ b/examples/express-graphql-http/server.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 
 import * as express from "express";
-import { createHandler } from 'graphql-http/lib/use/express';
+import { createHandler } from "graphql-http/lib/use/express";
 
 import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
 import Query from "./Query";
@@ -9,8 +9,6 @@ import Query from "./Query";
 async function main() {
   const app = express();
 
-  // FIXME: This is relative to the current working directory, not the file, or
-  // something more sensible.
   const schema = getSchema();
 
   app.post(

--- a/examples/express-graphql/schema.graphql
+++ b/examples/express-graphql/schema.graphql
@@ -2,7 +2,7 @@ schema {
   query: Query
 }
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
@@ -17,7 +17,7 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(filename: "../../examples/express-graphql/dist/models/User.js", functionName: "allUsers")
+  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql/dist/models/User.js", tsModulePath: "../../examples/express-graphql/models/User.ts", functionName: "allUsers")
   me: User!
   person: IPerson!
 }

--- a/examples/express-graphql/schema.graphql
+++ b/examples/express-graphql/schema.graphql
@@ -17,7 +17,7 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(jsModulePath: "../../examples/express-graphql/dist/models/User.js", tsModulePath: "../../examples/express-graphql/models/User.ts", functionName: "allUsers")
+  allUsers: [User!]! @exported(jsModulePath: "examples/express-graphql/dist/models/User.js", tsModulePath: "examples/express-graphql/models/User.ts", functionName: "allUsers")
   me: User!
   person: IPerson!
 }

--- a/examples/express-graphql/server.ts
+++ b/examples/express-graphql/server.ts
@@ -7,9 +7,6 @@ import { readFileSync } from "fs";
 async function main() {
   const app = express();
 
-  // FIXME: This is relative to the current working directory, not the file, or
-  // something more sensible.
-
   const schema = getSchema();
 
   app.use(

--- a/examples/ts-node/Query.ts
+++ b/examples/ts-node/Query.ts
@@ -1,0 +1,20 @@
+import IPerson from "./interfaces/IPerson";
+import User from "./models/User";
+
+// NOTE: Yoga does not support providing a `rootValue` to the executor. This
+// means that we cannot use a concrete value such as a class or an object
+// literal for Query or Mutation.
+//
+// Instead we use an empty type typed as `unknown`.
+
+/** @gqlType */
+export type Query = unknown;
+
+/** @gqlField */
+export function me(_: Query): User {
+  return new User();
+}
+/** @gqlField */
+export function person(_: Query): IPerson {
+  return new User();
+}

--- a/examples/ts-node/README.md
+++ b/examples/ts-node/README.md
@@ -1,0 +1,10 @@
+# Grats + esbuild-register
+
+Simple demo project integrating [Grats](https://grats.capt.dev/) and [esbuild-register](https://github.com/egoist/esbuild-register).
+
+This demonstrates Grats working with runtime TypeScript compilation. The same approach should work with similar tools like `ts-node`. See `scripts.start` in `package.json` for the relevant code.
+
+## Running the demo
+
+- `$ pnpm install`
+- `$ pnpm run start`

--- a/examples/ts-node/interfaces/IPerson.ts
+++ b/examples/ts-node/interfaces/IPerson.ts
@@ -1,0 +1,5 @@
+/** @gqlInterface */
+export default interface IPerson {
+  /** @gqlField */
+  name(): string;
+}

--- a/examples/ts-node/models/Group.ts
+++ b/examples/ts-node/models/Group.ts
@@ -1,0 +1,20 @@
+import User from "./User";
+
+/** @gqlType */
+export default class Group {
+  /** @gqlField */
+  description: string;
+
+  constructor() {
+    this.description = "A group of people";
+  }
+
+  /** @gqlField */
+  name(): string {
+    return "Pal's Club";
+  }
+  /** @gqlField */
+  async members(): Promise<User[]> {
+    return [new User()];
+  }
+}

--- a/examples/ts-node/models/User.ts
+++ b/examples/ts-node/models/User.ts
@@ -1,0 +1,21 @@
+import IPerson from "../interfaces/IPerson";
+import { Query } from "../Query";
+import Group from "./Group";
+
+/** @gqlType User */
+export default class UserResolver implements IPerson {
+  __typename = "User";
+  /** @gqlField */
+  name(): string {
+    return "Alice";
+  }
+  /** @gqlField */
+  groups(): Group[] {
+    return [new Group()];
+  }
+}
+
+/** @gqlField */
+export function allUsers(_: Query): UserResolver[] {
+  return [new UserResolver(), new UserResolver()];
+}

--- a/examples/ts-node/package.json
+++ b/examples/ts-node/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "grats-example-esbuild-register",
+  "version": "0.0.0",
+  "description": "Example server showcasing Grats used with esbuild-register",
+  "main": "index.js",
+  "scripts": {
+    "start": "ts-node server.ts",
+    "build": ""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/captbaritone/grats.git"
+  },
+  "keywords": [
+    "graphql",
+    "grats",
+    "yoga",
+    "javascript",
+    "typescript",
+    "esbuild",
+    "esbuild-register"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/captbaritone/grats/issues"
+  },
+  "homepage": "https://github.com/captbaritone/grats#readme",
+  "dependencies": {
+    "@types/node": "^20.8.10",
+    "graphql-yoga": "^5.0.0",
+    "grats": "workspace:*"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
+  }
+}

--- a/examples/ts-node/schema.graphql
+++ b/examples/ts-node/schema.graphql
@@ -1,0 +1,28 @@
+schema {
+  query: Query
+}
+
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
+
+directive @methodName(name: String!) on FIELD_DEFINITION
+
+type Group {
+  description: String!
+  members: [User!]!
+  name: String!
+}
+
+interface IPerson {
+  name: String!
+}
+
+type Query {
+  allUsers: [User!]! @exported(jsModulePath: "examples/ts-node/dist/models/User.js", tsModulePath: "examples/ts-node/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "examples/ts-node/dist/Query.js", tsModulePath: "examples/ts-node/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "examples/ts-node/dist/Query.js", tsModulePath: "examples/ts-node/Query.ts", functionName: "person")
+}
+
+type User implements IPerson {
+  groups: [Group!]!
+  name: String!
+}

--- a/examples/ts-node/server.ts
+++ b/examples/ts-node/server.ts
@@ -5,8 +5,6 @@ import { createYoga } from "graphql-yoga";
 import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
 
 async function main() {
-  // FIXME: This is relative to the current working directory, not the file, or
-  // something more sensible.
   const schema = getSchema();
 
   const yoga = createYoga({

--- a/examples/ts-node/server.ts
+++ b/examples/ts-node/server.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "fs";
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+
+import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
+
+async function main() {
+  // FIXME: This is relative to the current working directory, not the file, or
+  // something more sensible.
+  const schema = getSchema();
+
+  const yoga = createYoga({
+    schema,
+  });
+
+  const server = createServer(yoga);
+
+  server.listen(4000, () => {
+    console.log(
+      "Running a GraphQL API server at http://localhost:4000/graphql",
+    );
+  });
+}
+
+function getSchema() {
+  if (process.env.FROM_SDL) {
+    console.log("Building schema from SDL...");
+    const sdl = readFileSync("./schema.graphql", "utf8");
+    return buildSchemaFromSDL(sdl);
+  }
+  console.log("Building schema from source...");
+  return extractGratsSchemaAtRuntime({
+    emitSchemaFile: "./schema.graphql",
+  });
+}
+
+main();

--- a/examples/ts-node/tsconfig.json
+++ b/examples/ts-node/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "grats": {
+    "nullableByDefault": false
+  },
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "strict": true
+  }
+}

--- a/examples/yoga/schema.graphql
+++ b/examples/yoga/schema.graphql
@@ -2,7 +2,7 @@ schema {
   query: Query
 }
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(functionName: String!, jsModulePath: String!, tsModulePath: String!) on FIELD_DEFINITION
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
@@ -17,9 +17,9 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(filename: "../../examples/yoga/dist/models/User.js", functionName: "allUsers")
-  me: User! @exported(filename: "../../examples/yoga/dist/Query.js", functionName: "me")
-  person: IPerson! @exported(filename: "../../examples/yoga/dist/Query.js", functionName: "person")
+  allUsers: [User!]! @exported(jsModulePath: "../../examples/yoga/dist/models/User.js", tsModulePath: "../../examples/yoga/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "../../examples/yoga/dist/Query.js", tsModulePath: "../../examples/yoga/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "../../examples/yoga/dist/Query.js", tsModulePath: "../../examples/yoga/Query.ts", functionName: "person")
 }
 
 type User implements IPerson {

--- a/examples/yoga/schema.graphql
+++ b/examples/yoga/schema.graphql
@@ -17,9 +17,9 @@ interface IPerson {
 }
 
 type Query {
-  allUsers: [User!]! @exported(jsModulePath: "../../examples/yoga/dist/models/User.js", tsModulePath: "../../examples/yoga/models/User.ts", functionName: "allUsers")
-  me: User! @exported(jsModulePath: "../../examples/yoga/dist/Query.js", tsModulePath: "../../examples/yoga/Query.ts", functionName: "me")
-  person: IPerson! @exported(jsModulePath: "../../examples/yoga/dist/Query.js", tsModulePath: "../../examples/yoga/Query.ts", functionName: "person")
+  allUsers: [User!]! @exported(jsModulePath: "examples/yoga/dist/models/User.js", tsModulePath: "examples/yoga/models/User.ts", functionName: "allUsers")
+  me: User! @exported(jsModulePath: "examples/yoga/dist/Query.js", tsModulePath: "examples/yoga/Query.ts", functionName: "me")
+  person: IPerson! @exported(jsModulePath: "examples/yoga/dist/Query.js", tsModulePath: "examples/yoga/Query.ts", functionName: "person")
 }
 
 type User implements IPerson {

--- a/examples/yoga/server.ts
+++ b/examples/yoga/server.ts
@@ -5,8 +5,6 @@ import { createYoga } from "graphql-yoga";
 import { extractGratsSchemaAtRuntime, buildSchemaFromSDL } from "grats";
 
 async function main() {
-  // FIXME: This is relative to the current working directory, not the file, or
-  // something more sensible.
   const schema = getSchema();
 
   const yoga = createYoga({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,28 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
 
+  examples/ts-node:
+    dependencies:
+      '@types/node':
+        specifier: ^20.8.10
+        version: 20.8.10
+      graphql-yoga:
+        specifier: ^5.0.0
+        version: 5.0.0(graphql@16.6.0)
+      grats:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      esbuild:
+        specifier: ^0.19.7
+        version: 0.19.7
+      esbuild-register:
+        specifier: ^3.5.0
+        version: 3.5.0(esbuild@0.19.7)
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@20.8.10)(typescript@5.2.2)
+
   examples/yoga:
     dependencies:
       '@types/node':
@@ -5598,7 +5620,6 @@ packages:
     resolution: {integrity: sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==}
     dependencies:
       undici-types: 5.26.5
-    dev: false
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -15500,6 +15521,37 @@ packages:
       yn: 3.1.1
     dev: false
 
+  /ts-node@10.9.1(@types/node@20.8.10)(typescript@5.2.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 20.8.10
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -15602,7 +15654,6 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: false
 
   /ua-parser-js@0.7.35:
     resolution: {integrity: sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==}
@@ -15629,7 +15680,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: false
 
   /unherit@1.1.3:
     resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,25 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  examples/esbuild-register:
+    dependencies:
+      '@types/node':
+        specifier: ^20.8.10
+        version: 20.8.10
+      graphql-yoga:
+        specifier: ^5.0.0
+        version: 5.0.0(graphql@16.6.0)
+      grats:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      esbuild:
+        specifier: ^0.19.7
+        version: 0.19.7
+      esbuild-register:
+        specifier: ^3.5.0
+        version: 3.5.0(esbuild@0.19.7)
+
   examples/express-graphql:
     dependencies:
       express:
@@ -2911,6 +2930,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/android-arm64@0.19.7:
+    resolution: {integrity: sha512-YEDcw5IT7hW3sFKZBkCAQaOCJQLONVcD4bOyTXMZz5fr66pTHnAet46XAtbXAkJRfIn2YVhdC6R9g4xa27jQ1w==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm@0.19.4:
     resolution: {integrity: sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==}
     engines: {node: '>=12'}
@@ -2927,6 +2955,15 @@ packages:
     os: [android]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/android-arm@0.19.7:
+    resolution: {integrity: sha512-YGSPnndkcLo4PmVl2tKatEn+0mlVMr3yEpOOT0BeMria87PhvoJb5dg5f5Ft9fbCVgtAz4pWMzZVgSEGpDAlww==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.19.4:
@@ -2947,6 +2984,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/android-x64@0.19.7:
+    resolution: {integrity: sha512-jhINx8DEjz68cChFvM72YzrqfwJuFbfvSxZAk4bebpngGfNNRm+zRl4rtT9oAX6N9b6gBcFaJHFew5Blf6CvUw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.19.4:
     resolution: {integrity: sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==}
     engines: {node: '>=12'}
@@ -2963,6 +3009,15 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.7:
+    resolution: {integrity: sha512-dr81gbmWN//3ZnBIm6YNCl4p3pjnabg1/ZVOgz2fJoUO1a3mq9WQ/1iuEluMs7mCL+Zwv7AY5e3g1hjXqQZ9Iw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.4:
@@ -2983,6 +3038,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/darwin-x64@0.19.7:
+    resolution: {integrity: sha512-Lc0q5HouGlzQEwLkgEKnWcSazqr9l9OdV2HhVasWJzLKeOt0PLhHaUHuzb8s/UIya38DJDoUm74GToZ6Wc7NGQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.19.4:
     resolution: {integrity: sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==}
     engines: {node: '>=12'}
@@ -2999,6 +3063,15 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.7:
+    resolution: {integrity: sha512-+y2YsUr0CxDFF7GWiegWjGtTUF6gac2zFasfFkRJPkMAuMy9O7+2EH550VlqVdpEEchWMynkdhC9ZjtnMiHImQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.4:
@@ -3019,6 +3092,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/freebsd-x64@0.19.7:
+    resolution: {integrity: sha512-CdXOxIbIzPJmJhrpmJTLx+o35NoiKBIgOvmvT+jeSadYiWJn0vFKsl+0bSG/5lwjNHoIDEyMYc/GAPR9jxusTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64@0.19.4:
     resolution: {integrity: sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==}
     engines: {node: '>=12'}
@@ -3035,6 +3117,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.7:
+    resolution: {integrity: sha512-inHqdOVCkUhHNvuQPT1oCB7cWz9qQ/Cz46xmVe0b7UXcuIJU3166aqSunsqkgSGMtUCWOZw3+KMwI6otINuC9g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.19.4:
@@ -3055,6 +3146,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-arm@0.19.7:
+    resolution: {integrity: sha512-Y+SCmWxsJOdQtjcBxoacn/pGW9HDZpwsoof0ttL+2vGcHokFlfqV666JpfLCSP2xLxFpF1lj7T3Ox3sr95YXww==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.19.4:
     resolution: {integrity: sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==}
     engines: {node: '>=12'}
@@ -3071,6 +3171,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.7:
+    resolution: {integrity: sha512-2BbiL7nLS5ZO96bxTQkdO0euGZIUQEUXMTrqLxKUmk/Y5pmrWU84f+CMJpM8+EHaBPfFSPnomEaQiG/+Gmh61g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.4:
@@ -3091,6 +3200,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-loong64@0.19.7:
+    resolution: {integrity: sha512-BVFQla72KXv3yyTFCQXF7MORvpTo4uTA8FVFgmwVrqbB/4DsBFWilUm1i2Oq6zN36DOZKSVUTb16jbjedhfSHw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.19.4:
     resolution: {integrity: sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==}
     engines: {node: '>=12'}
@@ -3107,6 +3225,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.7:
+    resolution: {integrity: sha512-DzAYckIaK+pS31Q/rGpvUKu7M+5/t+jI+cdleDgUwbU7KdG2eC3SUbZHlo6Q4P1CfVKZ1lUERRFP8+q0ob9i2w==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.4:
@@ -3127,6 +3254,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-ppc64@0.19.7:
+    resolution: {integrity: sha512-JQ1p0SmUteNdUaaiRtyS59GkkfTW0Edo+e0O2sihnY4FoZLz5glpWUQEKMSzMhA430ctkylkS7+vn8ziuhUugQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.19.4:
     resolution: {integrity: sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==}
     engines: {node: '>=12'}
@@ -3143,6 +3279,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.7:
+    resolution: {integrity: sha512-xGwVJ7eGhkprY/nB7L7MXysHduqjpzUl40+XoYDGC4UPLbnG+gsyS1wQPJ9lFPcxYAaDXbdRXd1ACs9AE9lxuw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.4:
@@ -3163,6 +3308,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-s390x@0.19.7:
+    resolution: {integrity: sha512-U8Rhki5PVU0L0nvk+E8FjkV8r4Lh4hVEb9duR6Zl21eIEYEwXz8RScj4LZWA2i3V70V4UHVgiqMpszXvG0Yqhg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64@0.19.4:
     resolution: {integrity: sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==}
     engines: {node: '>=12'}
@@ -3179,6 +3333,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/linux-x64@0.19.7:
+    resolution: {integrity: sha512-ZYZopyLhm4mcoZXjFt25itRlocKlcazDVkB4AhioiL9hOWhDldU9n38g62fhOI4Pth6vp+Mrd5rFKxD0/S+7aQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.4:
@@ -3199,6 +3362,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/netbsd-x64@0.19.7:
+    resolution: {integrity: sha512-/yfjlsYmT1O3cum3J6cmGG16Fd5tqKMcg5D+sBYLaOQExheAJhqr8xOAEIuLo8JYkevmjM5zFD9rVs3VBcsjtQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.19.4:
     resolution: {integrity: sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==}
     engines: {node: '>=12'}
@@ -3215,6 +3387,15 @@ packages:
     os: [openbsd]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.7:
+    resolution: {integrity: sha512-MYDFyV0EW1cTP46IgUJ38OnEY5TaXxjoDmwiTXPjezahQgZd+j3T55Ht8/Q9YXBM0+T9HJygrSRGV5QNF/YVDQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.4:
@@ -3235,6 +3416,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/sunos-x64@0.19.7:
+    resolution: {integrity: sha512-JcPvgzf2NN/y6X3UUSqP6jSS06V0DZAV/8q0PjsZyGSXsIGcG110XsdmuWiHM+pno7/mJF6fjH5/vhUz/vA9fw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.19.4:
     resolution: {integrity: sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==}
     engines: {node: '>=12'}
@@ -3251,6 +3441,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.7:
+    resolution: {integrity: sha512-ZA0KSYti5w5toax5FpmfcAgu3ZNJxYSRm0AW/Dao5up0YV1hDVof1NvwLomjEN+3/GMtaWDI+CIyJOMTRSTdMw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.19.4:
@@ -3271,6 +3470,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/win32-ia32@0.19.7:
+    resolution: {integrity: sha512-CTOnijBKc5Jpk6/W9hQMMvJnsSYRYgveN6O75DTACCY18RA2nqka8dTZR+x/JqXCRiKk84+5+bRKXUSbbwsS0A==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.19.4:
     resolution: {integrity: sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==}
     engines: {node: '>=12'}
@@ -3287,6 +3495,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@esbuild/win32-x64@0.19.7:
+    resolution: {integrity: sha512-gRaP2sk6hc98N734luX4VpF318l3w+ofrtTu9j5L8EQXF+FzQKV6alCOHMVoJJHvVK/mGbwBXfOL1HETQu9IGQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.2.0(eslint@8.36.0):
@@ -8351,6 +8568,17 @@ packages:
     resolution: {integrity: sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==}
     dev: false
 
+  /esbuild-register@3.5.0(esbuild@0.19.7):
+    resolution: {integrity: sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+    dependencies:
+      debug: 4.3.4(supports-color@9.3.1)
+      esbuild: 0.19.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /esbuild@0.19.4:
     resolution: {integrity: sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==}
     engines: {node: '>=12'}
@@ -8410,6 +8638,36 @@ packages:
       '@esbuild/win32-ia32': 0.19.5
       '@esbuild/win32-x64': 0.19.5
     dev: false
+
+  /esbuild@0.19.7:
+    resolution: {integrity: sha512-6brbTZVqxhqgbpqBR5MzErImcpA0SQdoKOkcWK/U30HtQxnokIpG3TX2r0IJqbFUzqLjhU/zC1S5ndgakObVCQ==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.19.7
+      '@esbuild/android-arm64': 0.19.7
+      '@esbuild/android-x64': 0.19.7
+      '@esbuild/darwin-arm64': 0.19.7
+      '@esbuild/darwin-x64': 0.19.7
+      '@esbuild/freebsd-arm64': 0.19.7
+      '@esbuild/freebsd-x64': 0.19.7
+      '@esbuild/linux-arm': 0.19.7
+      '@esbuild/linux-arm64': 0.19.7
+      '@esbuild/linux-ia32': 0.19.7
+      '@esbuild/linux-loong64': 0.19.7
+      '@esbuild/linux-mips64el': 0.19.7
+      '@esbuild/linux-ppc64': 0.19.7
+      '@esbuild/linux-riscv64': 0.19.7
+      '@esbuild/linux-s390x': 0.19.7
+      '@esbuild/linux-x64': 0.19.7
+      '@esbuild/netbsd-x64': 0.19.7
+      '@esbuild/openbsd-x64': 0.19.7
+      '@esbuild/sunos-x64': 0.19.7
+      '@esbuild/win32-arm64': 0.19.7
+      '@esbuild/win32-ia32': 0.19.7
+      '@esbuild/win32-x64': 0.19.7
+    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,12 +152,6 @@ importers:
         specifier: workspace:*
         version: link:../..
     devDependencies:
-      esbuild:
-        specifier: ^0.19.7
-        version: 0.19.7
-      esbuild-register:
-        specifier: ^3.5.0
-        version: 3.5.0(esbuild@0.19.7)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@20.8.10)(typescript@5.2.2)

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -33,10 +33,11 @@ import { traverseJSDocTags } from "./utils/JSDoc";
 import { GraphQLConstructor } from "./GraphQLConstructor";
 import {
   EXPORTED_DIRECTIVE,
-  EXPORTED_FILENAME_ARG,
   EXPORTED_FUNCTION_NAME_ARG,
+  JS_MODULE_PATH_ARG,
   METHOD_NAME_ARG,
   METHOD_NAME_DIRECTIVE,
+  TS_MODULE_PATH_ARG,
 } from "./serverDirectives";
 
 export const LIBRARY_IMPORT_NAME = "grats";
@@ -371,13 +372,16 @@ export class Extractor {
     }
 
     // TODO: Does this work in the browser?
-    const filename = this.ctx.getDestFilePath(node.parent);
+    const { jsModulePath, tsModulePath } = this.ctx.getDestFilePath(
+      node.parent,
+    );
 
     const directives = [
-      this.exportDirective(funcName, filename, funcName.text),
+      this.exportDirective(funcName, jsModulePath, tsModulePath, funcName.text),
     ];
 
     if (funcName.text !== name.value) {
+      // TODO: Do we even need this?
       directives.push(this.fieldNameDirective(funcName, funcName.text));
     }
 
@@ -1725,7 +1729,8 @@ export class Extractor {
   /* Grats directives */
   exportDirective(
     nameNode: ts.Node,
-    filename: string,
+    jsModulePath: string,
+    tsModulePath: string,
     functionName: string,
   ): ConstDirectiveNode {
     return this.gql.constDirective(
@@ -1734,8 +1739,13 @@ export class Extractor {
       [
         this.gql.constArgument(
           nameNode,
-          this.gql.name(nameNode, EXPORTED_FILENAME_ARG),
-          this.gql.string(nameNode, filename),
+          this.gql.name(nameNode, JS_MODULE_PATH_ARG),
+          this.gql.string(nameNode, jsModulePath),
+        ),
+        this.gql.constArgument(
+          nameNode,
+          this.gql.name(nameNode, TS_MODULE_PATH_ARG),
+          this.gql.string(nameNode, tsModulePath),
         ),
         this.gql.constArgument(
           nameNode,

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -380,11 +380,6 @@ export class Extractor {
       this.exportDirective(funcName, jsModulePath, tsModulePath, funcName.text),
     ];
 
-    if (funcName.text !== name.value) {
-      // TODO: Do we even need this?
-      directives.push(this.fieldNameDirective(funcName, funcName.text));
-    }
-
     const deprecated = this.collectDeprecated(node);
     if (deprecated != null) {
       directives.push(deprecated);

--- a/src/TypeContext.ts
+++ b/src/TypeContext.ts
@@ -357,7 +357,10 @@ export class TypeContext {
     return ok(null);
   }
 
-  getDestFilePath(sourceFile: ts.SourceFile): string {
+  getDestFilePath(sourceFile: ts.SourceFile): {
+    jsModulePath: string;
+    tsModulePath: string;
+  } {
     return getRelativeOutputPath(this._options, sourceFile);
   }
 }

--- a/src/gratsRoot.ts
+++ b/src/gratsRoot.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from "path";
+import { relative, resolve, join } from "path";
 import * as ts from "typescript";
 
 // Grats parses TypeScript files and finds resolvers. If the field resolver is a
@@ -9,7 +9,7 @@ import * as ts from "typescript";
 // paths to be relative, they must be relative to something that both the build
 
 // step and the runtime can agree on. This path is that thing.
-const gratsRoot = __dirname;
+const gratsRoot = join(__dirname, "../..");
 
 export function getRelativeOutputPath(
   options: ts.ParsedCommandLine,

--- a/src/gratsRoot.ts
+++ b/src/gratsRoot.ts
@@ -14,7 +14,10 @@ const gratsRoot = __dirname;
 export function getRelativeOutputPath(
   options: ts.ParsedCommandLine,
   sourceFile: ts.SourceFile,
-) {
+): {
+  jsModulePath: string;
+  tsModulePath: string;
+} {
   const fileNames = ts.getOutputFileNames(options, sourceFile.fileName, true);
 
   // ts.getOutputFileNames returns a list of files that includes both the .d.ts
@@ -29,7 +32,9 @@ export function getRelativeOutputPath(
     );
   }
 
-  return relative(gratsRoot, fileNames[0]);
+  const jsModulePath = relative(gratsRoot, fileNames[0]);
+  const tsModulePath = relative(gratsRoot, sourceFile.fileName);
+  return { jsModulePath, tsModulePath };
 }
 
 export function resolveRelativePath(relativePath: string): string {

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -144,9 +144,12 @@ function importWithFallback(
   tsModulePath: string,
 ): Promise<Record<string, any>> {
   try {
-    return import(jsModulePath);
-  } catch (e) {
+    // We start with the .ts version because if both exist, and can be loaded, the .ts version is
+    // going to be more up to date. The downside is that this causes some extra work to be done in
+    // in prod. This should be manageable since we cache the loaded module for each field.
     return import(tsModulePath);
+  } catch (e) {
+    return import(jsModulePath);
   }
 }
 

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -139,7 +139,7 @@ function applyExportDirective(
 // compiled JavaScript version of the file may not exist on disk. In these specific
 // cases, esbuild or ts-node can load the file via its TypeScript source, so we try
 // falling back to that.
-function importWithFallback(
+async function importWithFallback(
   jsModulePath: string,
   tsModulePath: string,
 ): Promise<Record<string, any>> {
@@ -147,9 +147,12 @@ function importWithFallback(
     // We start with the .ts version because if both exist, and can be loaded, the .ts version is
     // going to be more up to date. The downside is that this causes some extra work to be done in
     // in prod. This should be manageable since we cache the loaded module for each field.
-    return import(tsModulePath);
+
+    // It's important that we await here so that we catch the error if the module doesn't exist or
+    // cannot be parsed.
+    return await import(tsModulePath);
   } catch (e) {
-    return import(jsModulePath);
+    return await import(jsModulePath);
   }
 }
 

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -26,6 +26,8 @@ export const DIRECTIVES_AST: DocumentNode = parse(`
 `);
 
 export function applyServerDirectives(schema: GraphQLSchema): GraphQLSchema {
+  // TODO: Throw if the schema is missing our directives!
+
   // TODO: Do we really need all of mapSchema here or can we create our own
   // thing that's simpler.
   return mapSchema(schema, {

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -12,13 +12,15 @@ import { resolveRelativePath } from "./gratsRoot";
 export const METHOD_NAME_DIRECTIVE = "methodName";
 export const METHOD_NAME_ARG = "name";
 export const EXPORTED_DIRECTIVE = "exported";
-export const EXPORTED_FILENAME_ARG = "filename";
+export const JS_MODULE_PATH_ARG = "jsModulePath";
+export const TS_MODULE_PATH_ARG = "tsModulePath";
 export const EXPORTED_FUNCTION_NAME_ARG = "functionName";
 
 export const DIRECTIVES_AST: DocumentNode = parse(`
     directive @${METHOD_NAME_DIRECTIVE}(${METHOD_NAME_ARG}: String!) on FIELD_DEFINITION
     directive @${EXPORTED_DIRECTIVE}(
-      ${EXPORTED_FILENAME_ARG}: String!,
+      ${JS_MODULE_PATH_ARG}: String!,
+      ${TS_MODULE_PATH_ARG}: String!,
       ${EXPORTED_FUNCTION_NAME_ARG}: String!
     ) on FIELD_DEFINITION
 `);
@@ -98,29 +100,65 @@ function applyExportDirective(
   methodNameDirective: Record<string, any>,
 ): GraphQLFieldConfig<any, any, any> {
   // TODO: Does this work in the browser?
-  const filename = resolveRelativePath(
-    methodNameDirective[EXPORTED_FILENAME_ARG],
+  const jsModulePath = resolveRelativePath(
+    methodNameDirective[JS_MODULE_PATH_ARG],
+  );
+  const tsModulePath = resolveRelativePath(
+    methodNameDirective[TS_MODULE_PATH_ARG],
   );
   const functionName = methodNameDirective[EXPORTED_FUNCTION_NAME_ARG];
+  let mod: Record<string, any> | undefined = undefined;
+  let modPromise: Promise<Record<string, any>> | undefined = undefined;
   return {
     ...fieldConfig,
     async resolve(source, args, context, info) {
-      let mod: any = {};
-      try {
-        mod = await import(filename);
-      } catch (e) {
-        console.error(
-          `Grats Error: Failed to import module \`${filename}\`. You may need to rerun Grats.`,
-        );
-        throw e;
+      if (modPromise == null) {
+        modPromise = importWithFallback(jsModulePath, tsModulePath);
+      }
+      if (mod == null) {
+        try {
+          mod = await modPromise;
+        } catch (e) {
+          console.error(loadModuleErrorMessage(jsModulePath, tsModulePath));
+          throw e;
+        }
       }
       const resolve = mod[functionName];
       if (typeof resolve !== "function") {
+        // TODO: Better error message that indicates if it was loaded from JS or TS.
         throw new Error(
-          `Grats Error: Expected \`${filename}\` to have a named export \`${functionName}\` that is a function, but it was \`${typeof resolve}\`. You may need to rerun Grats.`,
+          `Grats Error: Expected \`${tsModulePath}\` to have a named export \`${functionName}\` that is a function, but it was \`${typeof resolve}\`. You may need to rerun Grats or regenerate the JavaScript version of your module by rerunning the TypeScript compiler.`,
         );
       }
       return resolve(source, args, context, info);
     },
   };
+}
+
+// When people use Grats with loaders like `esbuild-register` or `ts-node`, the
+// compiled JavaScript version of the file may not exist on disk. In these specific
+// cases, esbuild or ts-node can load the file via its TypeScript source, so we try
+// falling back to that.
+function importWithFallback(
+  jsModulePath: string,
+  tsModulePath: string,
+): Promise<Record<string, any>> {
+  try {
+    return import(jsModulePath);
+  } catch (e) {
+    return import(tsModulePath);
+  }
+}
+
+function loadModuleErrorMessage(jsPath: string, tsPath: string): string {
+  return `Grats Error: Failed to import module. Tried loading from two locations:
+* \`${jsPath}\`
+* \`${tsPath}\`
+
+This can happen for a few reasons:
+
+* You resolver has moved and you need to rerun Grats to regenerate your schema.
+* Your TypeScript code has changed and you need to run \`tsc\` to generate the JavaScript variant of the file.
+* You compiled your TypeScript with a different TSConfig than what you ran Grats with.
+* The Grats NPM module moved between when you ran Grats and when you ran your server.`;
 }

--- a/src/serverDirectives.ts
+++ b/src/serverDirectives.ts
@@ -166,7 +166,7 @@ function loadModuleErrorMessage(jsPath: string, tsPath: string): string {
 This can happen for a few reasons:
 
 * You resolver has moved and you need to rerun Grats to regenerate your schema.
-* Your TypeScript code has changed and you need to run \`tsc\` to generate the JavaScript variant of the file.
+* Your TypeScript code has changed and you need to rerun \`tsc\` to generate the JavaScript variant of the file.
 * You compiled your TypeScript with a different TSConfig than what you ran Grats with.
 * The Grats NPM module moved between when you ran Grats and when you ran your server.`;
 }

--- a/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
+++ b/src/tests/fixtures/arguments/ArgumentWithDescription.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(

--- a/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
+++ b/src/tests/fixtures/arguments/CustomScalarArgument.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 scalar MyString
 

--- a/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
+++ b/src/tests/fixtures/arguments/DeprecatedArgument.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(greeting: String @deprecated(reason: "Not used anymore")): String

--- a/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
+++ b/src/tests/fixtures/arguments/NoArgsWithUnknown.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/arguments/NullableArgument.ts.expected
+++ b/src/tests/fixtures/arguments/NullableArgument.ts.expected
@@ -34,7 +34,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello1(greeting: String): String

--- a/src/tests/fixtures/arguments/OptionalArgument.ts.expected
+++ b/src/tests/fixtures/arguments/OptionalArgument.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(greeting: String): String

--- a/src/tests/fixtures/arguments/StringArgument.ts.expected
+++ b/src/tests/fixtures/arguments/StringArgument.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(greeting: String!): String

--- a/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatField.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   ratio: Float

--- a/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/FloatFieldAliasedImport.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   ratio: Float

--- a/src/tests/fixtures/built_in_scalars/IdField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IdField.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   id: ID

--- a/src/tests/fixtures/built_in_scalars/IntField.ts.expected
+++ b/src/tests/fixtures/built_in_scalars/IntField.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   age: Int

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalar.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineCustomScalarWithDescription.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
+++ b/src/tests/fixtures/custom_scalars/DefineRenamedCustomScalar.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentArray.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   someField1(inputs: [String!] = ["hello", "there"]): String

--- a/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentBooleanLiteral.ts.expected
@@ -21,7 +21,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   someField1(greet: Boolean = false): String

--- a/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNullLiteral.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   someField1(hello: String = null): String

--- a/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentNumberLiteral.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   intField(count: Int! = 10): String

--- a/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentObjectLiteral.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   someField1(input: ConnectionInput = {first: 10, offset: 100}): String

--- a/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
+++ b/src/tests/fixtures/default_values/DefaultArgumentStringLiteral.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(greeting: String! = "hello"): String

--- a/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesAroundDescription.ts.expected
@@ -32,7 +32,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """Sup"""
 type SomeType {

--- a/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
+++ b/src/tests/fixtures/descriptions/BlankLinesFollowTypeTag.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   name: String

--- a/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
+++ b/src/tests/fixtures/descriptions/MultilineDescription.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """
 ’Twas brillig, and the slithy toves

--- a/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
+++ b/src/tests/fixtures/enums/DeprecatedEnumVariant.ts.expected
@@ -23,7 +23,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/enums/Enum.ts.expected
+++ b/src/tests/fixtures/enums/Enum.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionType.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiterals.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDeprecated.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfAliaedStringLiteralsWithDescriptions.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeOfStringLiteral.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumFromUnionTypeWithDescription.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
+++ b/src/tests/fixtures/enums/EnumValuesDifferentThanNames.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/enums/EnumWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithDescription.ts.expected
@@ -22,7 +22,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/enums/EnumWithVariantWithDescription.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/examples/playground.ts.expected
+++ b/src/tests/fixtures/examples/playground.ts.expected
@@ -45,7 +45,7 @@ directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: 
 type SomeType {
   me: User
   viewer: User @deprecated(reason: "Please use `me` instead.")
-  getUser: User @exported(jsModulePath: "tests/fixtures/examples/playground.js", tsModulePath: "tests/fixtures/examples/playground.ts", functionName: "getUser")
+  getUser: User @exported(jsModulePath: "grats/src/tests/fixtures/examples/playground.js", tsModulePath: "grats/src/tests/fixtures/examples/playground.ts", functionName: "getUser")
 }
 
 """A user in our kick-ass system!"""

--- a/src/tests/fixtures/examples/playground.ts.expected
+++ b/src/tests/fixtures/examples/playground.ts.expected
@@ -40,12 +40,12 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User
   viewer: User @deprecated(reason: "Please use `me` instead.")
-  getUser: User @exported(filename: "tests/fixtures/examples/playground.js", functionName: "getUser")
+  getUser: User @exported(jsModulePath: "tests/fixtures/examples/playground.js", tsModulePath: "tests/fixtures/examples/playground.ts", functionName: "getUser")
 }
 
 """A user in our kick-ass system!"""

--- a/src/tests/fixtures/examples/readme.ts.expected
+++ b/src/tests/fixtures/examples/readme.ts.expected
@@ -39,7 +39,7 @@ schema {
 
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type Query {
   me: User

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
@@ -34,7 +34,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface IPerson {
   hello: String
@@ -43,10 +43,10 @@ interface IPerson {
 
 type User implements IPerson {
   hello: String
-  greeting: String @exported(filename: "tests/fixtures/extend_interface/addStringFieldToInterface.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
 }
 
 type Admin implements IPerson {
   hello: String
-  greeting: String @exported(filename: "tests/fixtures/extend_interface/addStringFieldToInterface.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
@@ -43,10 +43,10 @@ interface IPerson {
 
 type User implements IPerson {
   hello: String
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
 }
 
 type Admin implements IPerson {
   hello: String
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.js", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
@@ -50,9 +50,9 @@ interface IPerson implements IThing {
 }
 
 type User implements IPerson & IThing {
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
 }
 
 type Admin implements IPerson & IThing {
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
@@ -39,7 +39,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface IThing {
   greeting: String
@@ -50,9 +50,9 @@ interface IPerson implements IThing {
 }
 
 type User implements IPerson & IThing {
-  greeting: String @exported(filename: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
 }
 
 type Admin implements IPerson & IThing {
-  greeting: String @exported(filename: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.js", tsModulePath: "tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
@@ -22,5 +22,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @deprecated(reason: "Because reasons") @exported(jsModulePath: "tests/fixtures/extend_type/addDeprecatedField.js", tsModulePath: "tests/fixtures/extend_type/addDeprecatedField.ts", functionName: "greeting")
+  greeting: String @deprecated(reason: "Because reasons") @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addDeprecatedField.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addDeprecatedField.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
@@ -19,8 +19,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @deprecated(reason: "Because reasons") @exported(filename: "tests/fixtures/extend_type/addDeprecatedField.js", functionName: "greeting")
+  greeting: String @deprecated(reason: "Because reasons") @exported(jsModulePath: "tests/fixtures/extend_type/addDeprecatedField.js", tsModulePath: "tests/fixtures/extend_type/addDeprecatedField.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
@@ -19,5 +19,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting(name: String!): String @exported(jsModulePath: "tests/fixtures/extend_type/addFieldWithArguments.js", tsModulePath: "tests/fixtures/extend_type/addFieldWithArguments.ts", functionName: "greeting")
+  greeting(name: String!): String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithArguments.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithArguments.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
@@ -16,8 +16,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting(name: String!): String @exported(filename: "tests/fixtures/extend_type/addFieldWithArguments.js", functionName: "greeting")
+  greeting(name: String!): String @exported(jsModulePath: "tests/fixtures/extend_type/addFieldWithArguments.js", tsModulePath: "tests/fixtures/extend_type/addFieldWithArguments.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
@@ -23,5 +23,5 @@ directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: 
 
 type SomeType {
   """Best field ever!"""
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/addFieldWithDescription.js", tsModulePath: "tests/fixtures/extend_type/addFieldWithDescription.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithDescription.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithDescription.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
@@ -19,9 +19,9 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   """Best field ever!"""
-  greeting: String @exported(filename: "tests/fixtures/extend_type/addFieldWithDescription.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/addFieldWithDescription.js", tsModulePath: "tests/fixtures/extend_type/addFieldWithDescription.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -19,5 +19,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  hello: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting") @methodName(name: "greeting")
+  hello: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -16,8 +16,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  hello: String @exported(filename: "tests/fixtures/extend_type/addRenamedFieldToSomeType.js", functionName: "greeting") @methodName(name: "greeting")
+  hello: String @exported(jsModulePath: "tests/fixtures/extend_type/addRenamedFieldToSomeType.js", tsModulePath: "tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting") @methodName(name: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -19,5 +19,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  hello: String @exported(jsModulePath: "tests/fixtures/extend_type/addRenamedFieldToSomeType.js", tsModulePath: "tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting") @methodName(name: "greeting")
+  hello: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting") @methodName(name: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
@@ -19,5 +19,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/addStringFieldToSomeType.js", tsModulePath: "tests/fixtures/extend_type/addStringFieldToSomeType.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/addStringFieldToSomeType.js", tsModulePath: "grats/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
@@ -16,8 +16,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(filename: "tests/fixtures/extend_type/addStringFieldToSomeType.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/addStringFieldToSomeType.js", tsModulePath: "tests/fixtures/extend_type/addStringFieldToSomeType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
+++ b/src/tests/fixtures/extend_type/interfaceFirstArgumentType.ts.expected
@@ -23,7 +23,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   foo: String

--- a/src/tests/fixtures/extend_type/optionalModelType.ts.expected
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts.expected
@@ -26,5 +26,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/optionalModelType.js", tsModulePath: "tests/fixtures/extend_type/optionalModelType.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/extend_type/optionalModelType.js", tsModulePath: "grats/src/tests/fixtures/extend_type/optionalModelType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/extend_type/optionalModelType.ts.expected
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts.expected
@@ -23,8 +23,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(filename: "tests/fixtures/extend_type/optionalModelType.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/extend_type/optionalModelType.js", tsModulePath: "tests/fixtures/extend_type/optionalModelType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedMethodField.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String @deprecated(reason: "Use something else.")

--- a/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/DeprecatedPropertyField.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String @deprecated(reason: "Use something else.")

--- a/src/tests/fixtures/field_definitions/MethodSignatureOnInterface.ts.expected
+++ b/src/tests/fixtures/field_definitions/MethodSignatureOnInterface.ts.expected
@@ -12,7 +12,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface ICarly {
   name: String

--- a/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldDeprecated.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String @deprecated(reason: "Don't use this")

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnly.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldRenamed.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String @methodName(name: "foo")

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldWithDescription.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   """Greet the world!"""

--- a/src/tests/fixtures/field_definitions/RenamedField.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedField.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String @methodName(name: "somePropertyField")

--- a/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/RenamedFieldWithDescription.ts.expected
@@ -25,7 +25,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   """Number 1 greeting."""

--- a/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/field_definitions/StringFieldWithDescription.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   """Greet the world!"""

--- a/src/tests/fixtures/field_values/ArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: [String!]

--- a/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayShorthandField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: [String!]

--- a/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
+++ b/src/tests/fixtures/field_values/ArrayWithNullableItems.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: [String]

--- a/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
+++ b/src/tests/fixtures/field_values/AsyncPromiseField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_values/BooleanField.ts.expected
+++ b/src/tests/fixtures/field_values/BooleanField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   haveBeenGreeted: Boolean

--- a/src/tests/fixtures/field_values/CustomScalar.ts.expected
+++ b/src/tests/fixtures/field_values/CustomScalar.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 scalar MyString
 

--- a/src/tests/fixtures/field_values/KitchenSink.ts.expected
+++ b/src/tests/fixtures/field_values/KitchenSink.ts.expected
@@ -63,7 +63,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello(greeting: String!): String

--- a/src/tests/fixtures/field_values/LinkedField.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedField.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
+++ b/src/tests/fixtures/field_values/LinkedFieldWithTypeArg.ts.expected
@@ -28,7 +28,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/field_values/OptionalFields.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalFields.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_values/OptionalProperty.ts.expected
+++ b/src/tests/fixtures/field_values/OptionalProperty.ts.expected
@@ -12,7 +12,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
+++ b/src/tests/fixtures/field_values/ParenthesizedType.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: [String]

--- a/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
+++ b/src/tests/fixtures/field_values/ReadonlyArrayField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: [String!]

--- a/src/tests/fixtures/field_values/RenamedType.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedType.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User {
   name: String

--- a/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
+++ b/src/tests/fixtures/field_values/RenamedTypeOutOfOrder.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/field_values/StringField.ts.expected
+++ b/src/tests/fixtures/field_values/StringField.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
+++ b/src/tests/fixtures/field_values/StringFieldKillsParentOnException.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String!

--- a/src/tests/fixtures/field_values/UnionField.ts.expected
+++ b/src/tests/fixtures/field_values/UnionField.ts.expected
@@ -31,7 +31,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Actor

--- a/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NonNullablePromise.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String!

--- a/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
+++ b/src/tests/fixtures/field_values/non_default_nullable/NullablePromise.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/InputType.ts.expected
+++ b/src/tests/fixtures/input_types/InputType.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeOptionalField.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDeprecatedField.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithDescription.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeWithFieldDescription.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/input_types/RenamedInputType.ts.expected
+++ b/src/tests/fixtures/input_types/RenamedInputType.ts.expected
@@ -17,7 +17,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/FieldReturnsInterface.ts.expected
@@ -27,7 +27,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Person

--- a/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
+++ b/src/tests/fixtures/interfaces/IgnoresExtendsClause.ts.expected
@@ -31,7 +31,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterface.ts.expected
@@ -27,7 +27,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsInterfaceWithTypeParam.ts.expected
@@ -31,7 +31,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsMultipleInterfaces.ts.expected
@@ -33,7 +33,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/ImplementsRenamedInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/ImplementsRenamedInterface.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Person {
   name: String

--- a/src/tests/fixtures/interfaces/InterfaceDefinitionExtendsGqlInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceDefinitionExtendsGqlInterface.ts.expected
@@ -34,7 +34,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Mammal {
   legs: Int

--- a/src/tests/fixtures/interfaces/InterfaceExtendsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceExtendsInterface.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Node {
   id: String

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescription.ts.expected
@@ -30,7 +30,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceFieldWithDescriptionThatDiffersFromType.ts.expected
@@ -33,7 +33,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/InterfaceImplementsInterface.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceImplementsInterface.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Node {
   id: String

--- a/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithCustomName.ts.expected
@@ -27,7 +27,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDeprecatedField.ts.expected
@@ -29,7 +29,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithDescription.ts.expected
@@ -31,7 +31,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: User

--- a/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
+++ b/src/tests/fixtures/interfaces/InterfaceWithNameCollisionNotMerged.ts.expected
@@ -26,7 +26,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Node

--- a/src/tests/fixtures/interfaces/extendInterfaceWithNonGqlType.ts.expected
+++ b/src/tests/fixtures/interfaces/extendInterfaceWithNonGqlType.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface IPerson {
   name: String

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValue.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String

--- a/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
+++ b/src/tests/fixtures/resolver_context/ClassMethodWithContextValueExported.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String

--- a/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueOptional.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String

--- a/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
+++ b/src/tests/fixtures/resolver_context/ContextValueTypedAsUnknown.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
@@ -18,8 +18,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User {
-  greeting: String @exported(filename: "tests/fixtures/resolver_context/FunctionWithContextValue.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/resolver_context/FunctionWithContextValue.js", tsModulePath: "tests/fixtures/resolver_context/FunctionWithContextValue.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
@@ -21,5 +21,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User {
-  greeting: String @exported(jsModulePath: "tests/fixtures/resolver_context/FunctionWithContextValue.js", tsModulePath: "tests/fixtures/resolver_context/FunctionWithContextValue.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/resolver_context/FunctionWithContextValue.js", tsModulePath: "grats/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/MultipleClassMethodsReferencingContextValue.ts.expected
@@ -23,7 +23,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   greeting: String

--- a/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
+++ b/src/tests/fixtures/todo/EnumFromUnionTypeWithVariantWithDescription.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: MyEnum

--- a/src/tests/fixtures/todo/RedefineBuiltinScalar.invalid.ts.expected
+++ b/src/tests/fixtures/todo/RedefineBuiltinScalar.invalid.ts.expected
@@ -9,4 +9,4 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION

--- a/src/tests/fixtures/todo/userExample.ts.expected
+++ b/src/tests/fixtures/todo/userExample.ts.expected
@@ -30,11 +30,11 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  me: User @exported(jsModulePath: "tests/fixtures/todo/userExample.js", tsModulePath: "tests/fixtures/todo/userExample.ts", functionName: "me")
+  me: User @exported(jsModulePath: "grats/src/tests/fixtures/todo/userExample.js", tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts", functionName: "me")
 }
 
 type User {
   firstName: String
   lastName: String
-  fullName: String @exported(jsModulePath: "tests/fixtures/todo/userExample.js", tsModulePath: "tests/fixtures/todo/userExample.ts", functionName: "fullName")
+  fullName: String @exported(jsModulePath: "grats/src/tests/fixtures/todo/userExample.js", tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts", functionName: "fullName")
 }

--- a/src/tests/fixtures/todo/userExample.ts.expected
+++ b/src/tests/fixtures/todo/userExample.ts.expected
@@ -27,14 +27,14 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  me: User @exported(filename: "tests/fixtures/todo/userExample.js", functionName: "me")
+  me: User @exported(jsModulePath: "tests/fixtures/todo/userExample.js", tsModulePath: "tests/fixtures/todo/userExample.ts", functionName: "me")
 }
 
 type User {
   firstName: String
   lastName: String
-  fullName: String @exported(filename: "tests/fixtures/todo/userExample.js", functionName: "fullName")
+  fullName: String @exported(jsModulePath: "tests/fixtures/todo/userExample.js", tsModulePath: "tests/fixtures/todo/userExample.ts", functionName: "fullName")
 }

--- a/src/tests/fixtures/type_definitions/ClassImplementsNonGqlInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassImplementsNonGqlInterface.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type User {

--- a/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescription.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions/ClassWithDescriptionAndCustomName.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions/RenamedType.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsInterface.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Person {
   hello: String

--- a/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsMultipleInterfaces.ts.expected
+++ b/src/tests/fixtures/type_definitions/TypeFromClassDefinitionImplementsMultipleInterfaces.ts.expected
@@ -28,7 +28,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Node {
   id: String

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -17,5 +17,5 @@ directive @methodName(name: String!) on FIELD_DEFINITION
 directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(jsModulePath: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", tsModulePath: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -14,8 +14,8 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
-  greeting: String @exported(filename: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", functionName: "greeting")
+  greeting: String @exported(jsModulePath: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.js", tsModulePath: "tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts", functionName: "greeting")
 }

--- a/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasType.ts.expected
@@ -12,7 +12,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescription.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasWithDescriptionAndCustomName.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/RenamedType.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceType.ts.expected
@@ -12,7 +12,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeExtendsGqlInterface.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 interface Person {
   name: String

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeImplementsInterface.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceTypeImplementsInterface.ts.expected
@@ -22,7 +22,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User implements HasName {
   hello: String

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescription.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/InterfaceWithDescriptionAndCustomName.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 """The root of all evil."""
 type SomeType {

--- a/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_interface/RenamedType.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   hello: String

--- a/src/tests/fixtures/typename/PropertySignatureTypename.ts.expected
+++ b/src/tests/fixtures/typename/PropertySignatureTypename.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User implements IPerson {
   name: String

--- a/src/tests/fixtures/typename/PropertyTypename.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypename.ts.expected
@@ -13,7 +13,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type User {
   name: String

--- a/src/tests/fixtures/unions/DefineUnionType.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionType.ts.expected
@@ -29,7 +29,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Actor

--- a/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithInterfaces.ts.expected
@@ -29,7 +29,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Actor

--- a/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
+++ b/src/tests/fixtures/unions/DefineUnionTypeWithTypeLiterals.ts.expected
@@ -29,7 +29,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Actor

--- a/src/tests/fixtures/unions/UnionWithDescription.ts.expected
+++ b/src/tests/fixtures/unions/UnionWithDescription.ts.expected
@@ -32,7 +32,7 @@ OUTPUT
 -----------------
 directive @methodName(name: String!) on FIELD_DEFINITION
 
-directive @exported(filename: String!, functionName: String!) on FIELD_DEFINITION
+directive @exported(jsModulePath: String!, tsModulePath: String!, functionName: String!) on FIELD_DEFINITION
 
 type SomeType {
   me: Actor

--- a/src/tests/integration.mjs
+++ b/src/tests/integration.mjs
@@ -1,4 +1,4 @@
-import { fork } from "child_process";
+import { spawn } from "child_process";
 import fetch from "node-fetch";
 import assert from "assert";
 import fs from "fs";
@@ -59,9 +59,10 @@ async function fetchQuery(query, variables) {
 }
 
 async function withExampleServer(exampleDir, cb) {
-  const child = fork("./dist/server.js", {
+  const child = spawn("pnpm", ["run", "--silent", "start"], {
     cwd: exampleDir,
     stdio: "pipe",
+    detached: true,
   });
   child.stderr.on("data", (data) => {
     console.error(`${exampleDir} stderr: ${data}`);
@@ -80,7 +81,7 @@ async function withExampleServer(exampleDir, cb) {
     await awaitProcessData(child);
     await cb();
   } finally {
-    child.kill("SIGINT");
+    process.kill(-child.pid, "SIGTERM"); // Negative PID kills the entire process group
   }
 }
 

--- a/src/tests/integrationFixtures/functionFieldRenamed.ts
+++ b/src/tests/integrationFixtures/functionFieldRenamed.ts
@@ -1,0 +1,13 @@
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField hello */
+export function notHello(_: Query): string {
+  return "Hello World";
+}
+
+export const query = `
+    query {
+      hello
+    }
+  `;

--- a/src/tests/integrationFixtures/functionFieldRenamed.ts.expected
+++ b/src/tests/integrationFixtures/functionFieldRenamed.ts.expected
@@ -1,0 +1,25 @@
+-----------------
+INPUT
+----------------- 
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField hello */
+export function notHello(_: Query): string {
+  return "Hello World";
+}
+
+export const query = `
+    query {
+      hello
+    }
+  `;
+
+-----------------
+OUTPUT
+-----------------
+{
+  "data": {
+    "hello": "Hello World"
+  }
+}

--- a/website/docs/05-examples/06-esbuild-register.md
+++ b/website/docs/05-examples/06-esbuild-register.md
@@ -1,0 +1,10 @@
+# ESBuild Register
+
+A very minimal example showing using node's register `-r` flag and `esbuild-register` to compile TypeScript on the fly. This same approach should work with similar tools like `ts-node`.
+
+## Libraries used
+
+- `yoga-graphql`
+- `esbuild-register`
+
+https://github.com/captbaritone/grats/tree/main/examples/esbuild-register

--- a/website/docs/05-examples/07-ts-node.md
+++ b/website/docs/05-examples/07-ts-node.md
@@ -1,0 +1,10 @@
+# TS-Node
+
+A very minimal example showing using `ts-node` to compile TypeScript on the fly.
+
+## Libraries used
+
+- `yoga-graphql`
+- `ts-node`
+
+https://github.com/captbaritone/grats/tree/main/examples/ts-node

--- a/website/docs/05-examples/_category_.json
+++ b/website/docs/05-examples/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsed": false,
-  "collapsible": false
+  "collapsed": true,
+  "collapsible": true
 }

--- a/website/src/components/PlaygroundFeatures/editors/InputView.tsx
+++ b/website/src/components/PlaygroundFeatures/editors/InputView.tsx
@@ -69,7 +69,6 @@ function useFsMap() {
 // TODO: Make this into hooks
 async function createInputView(store, fsMap, left) {
   const state = store.getState();
-  console.log(state);
 
   // Create a selector that memoizes the linter and closes over the fsMap
   const getLinter = createSelector(getView, getConfig, (view, config) => {


### PR DESCRIPTION
This should enable using setups like `esbuild-register` which compiler .js files on the fly. Fixes #54.

Possible concerns:

* If you are mixing `esbuild-register` and `tsc` (for example for dev and release) you might get `.js` file when you expect the `.ts`
* Makes the already noisy directive even more noisy

## TODO

- [ ] ~Can we detect if we are using ts-node or `esbuild-register`?~
- [x] Should we start with `.ts` instead of `.js`? Slower in prod, but perhaps more predictable in dev?
- [x] Improve error message further
- [x] Check tests
- [x] Add integration tests (examples)
  - [ ] `esbuild-register`
  - [ ] `ts-node`
  - [ ] `ts-node` register
  - [ ] ESBuild loader
  - [ ] `ts-node` loader