### PR TITLE
Print SDL from SDL AST instead of GraphQL Schema

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,6 @@
 import { Location } from "graphql";
 import { getParsedTsConfig } from "./";
 import {
-  ConfigOptions,
-  ParsedCommandLineGrats,
   SchemaAndDoc,
   buildSchemaAndDocResult,
   extractSchemaAndDoc,
@@ -17,6 +15,7 @@ import { locate } from "./Locate";
 import { printGratsSDL, printExecutableSchema } from "./printSchema";
 import * as ts from "typescript";
 import { ReportableDiagnostics } from "./utils/DiagnosticError";
+import { ConfigOptions, ParsedCommandLineGrats } from "./gratsConfig";
 
 const program = new Command();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,13 +46,16 @@ program
   .action((entity, { tsconfig }) => {
     const { config } = getTsConfigOrReportAndExit(tsconfig);
 
-    const schemaResult = buildSchemaAndDocResult(config);
-    if (schemaResult.kind === "ERROR") {
-      console.error(schemaResult.err.formatDiagnosticsWithColorAndContext());
+    const schemaAndDocResult = buildSchemaAndDocResult(config);
+    if (schemaAndDocResult.kind === "ERROR") {
+      console.error(
+        schemaAndDocResult.err.formatDiagnosticsWithColorAndContext(),
+      );
       process.exit(1);
     }
+    const { schema } = schemaAndDocResult.value;
 
-    const loc = locate(schemaResult.value.schema, entity);
+    const loc = locate(schema, entity);
     if (loc.kind === "ERROR") {
       console.error(loc.err);
       process.exit(1);
@@ -92,13 +95,15 @@ function startWatchMode(tsconfig: string) {
  */
 function runBuild(tsconfig: string) {
   const { config, configPath } = getTsConfigOrReportAndExit(tsconfig);
-  const schemaResult = buildSchemaAndDocResult(config);
-  if (schemaResult.kind === "ERROR") {
-    console.error(schemaResult.err.formatDiagnosticsWithColorAndContext());
+  const schemaAndDocResult = buildSchemaAndDocResult(config);
+  if (schemaAndDocResult.kind === "ERROR") {
+    console.error(
+      schemaAndDocResult.err.formatDiagnosticsWithColorAndContext(),
+    );
     process.exit(1);
   }
 
-  writeSchemaFilesAndReport(schemaResult.value, config, configPath);
+  writeSchemaFilesAndReport(schemaAndDocResult.value, config, configPath);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import * as ts from "typescript";
-import { ParsedCommandLineGrats, validateGratsOptions } from "./lib";
+import { ParsedCommandLineGrats, validateGratsOptions } from "./gratsConfig";
 import { ReportableDiagnostics } from "./utils/DiagnosticError";
 import { err, ok } from "./utils/Result";
 import { Result } from "./utils/Result";
 
-export { printSDLWithoutDirectives } from "./printSchema";
+export { printSDLWithoutMetadata } from "./printSchema";
 export * from "./Types";
 export * from "./lib";
 // Used by the experimental TypeScript plugin

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -105,7 +105,9 @@ export function extractSchemaAndDoc(
         .andThen((doc) => resolveTypes(ctx, doc))
         // Ensure all subscription fields, and _only_ subscription fields, return an AsyncIterable.
         .andThen((doc) => validateAsyncIterable(doc))
+        // Merge any `extend` definitions into their base definitions.
         .map((doc) => mergeExtensions(doc))
+        // Sort the definitions in the document to ensure a stable output.
         .map((doc) => sortSchemaAst(doc))
         .result();
 
@@ -114,13 +116,13 @@ export function extractSchemaAndDoc(
       }
       const doc = docResult.value;
 
-      // Validate the document node against the GraphQL spec.
       // Build and validate the schema with regards to the GraphQL spec.
       return (
         new ResultPipe(buildSchemaFromDoc(doc))
           // Ensure that every type which implements an interface or is a member of a
           // union has a __typename field.
           .andThen((schema) => validateTypenames(schema, typesWithTypename))
+          // Combine the schema and document into a single result.
           .map((schema) => ({ schema, doc }))
           .result()
       );

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -5,14 +5,10 @@ import {
   printSchema,
   visit,
   specifiedScalarTypes,
-  NameNode,
-  Kind,
-  FieldDefinitionNode,
 } from "graphql";
-import { ConfigOptions } from "./lib";
+import { ConfigOptions } from "./gratsConfig";
 import { codegen } from "./codegen";
 import { METADATA_DIRECTIVE_NAMES } from "./metadataDirectives";
-import { extend } from "./utils/helpers";
 
 /**
  * Prints code for a TypeScript module that exports a GraphQLSchema.
@@ -67,7 +63,7 @@ export function printSDLWithoutDirectives(doc: DocumentNode): string {
       return t;
     },
   });
-  return print(sortDocument(mergeExtensions(trimmed)));
+  return print(trimmed);
 }
 
 export function printSDLFromSchemaWithoutDirectives(
@@ -81,138 +77,4 @@ export function printSDLFromSchemaWithoutDirectives(
       }),
     }),
   );
-}
-
-// Take every extension and merge it into the base type definition.
-function mergeExtensions(doc: DocumentNode): DocumentNode {
-  const fields = new MultiMap<string, FieldDefinitionNode>();
-  const sansExtensions = visit(doc, {
-    ObjectTypeExtension(t) {
-      if (t.directives != null || t.interfaces != null) {
-        throw new Error("Unexpected directives or interfaces on Extension");
-      }
-      fields.extend(t.name.value, t.fields);
-      return null;
-    },
-    InterfaceTypeExtension(t) {
-      if (t.directives != null || t.interfaces != null) {
-        throw new Error("Unexpected directives or interfaces on Extension");
-      }
-      fields.extend(t.name.value, t.fields);
-      return null;
-    },
-  });
-  return visit(sansExtensions, {
-    ObjectTypeDefinition(t) {
-      const extensions = fields.get(t.name.value);
-      if (t.fields == null) {
-        return { ...t, fields: extensions };
-      }
-      return { ...t, fields: [...t.fields, ...extensions] };
-    },
-    InterfaceTypeDefinition(t) {
-      const extensions = fields.get(t.name.value);
-      if (t.fields == null) {
-        return { ...t, fields: extensions };
-      }
-      return { ...t, fields: [...t.fields, ...extensions] };
-    },
-  });
-}
-
-class MultiMap<K, V> {
-  private readonly map = new Map<K, V[]>();
-
-  set(key: K, value: V): void {
-    let existing = this.map.get(key);
-    if (existing == null) {
-      existing = [];
-      this.map.set(key, existing);
-    }
-    existing.push(value);
-  }
-
-  extend(key: K, values?: readonly V[]): void {
-    if (values == null) {
-      return;
-    }
-    let existing = this.map.get(key);
-    if (existing == null) {
-      existing = [];
-      this.map.set(key, existing);
-    }
-    extend(existing, values);
-  }
-
-  get(key: K): V[] {
-    return this.map.get(key) ?? [];
-  }
-}
-
-function sortDocument(doc: DocumentNode): DocumentNode {
-  return visit(doc, {
-    ObjectTypeDefinition(t) {
-      return {
-        ...t,
-        directives: sortNamed(t.directives),
-        interfaces: sortNamed(t.interfaces),
-        fields: sortNamed(t.fields),
-      };
-    },
-    InterfaceTypeDefinition(t) {
-      return {
-        ...t,
-        directives: sortNamed(t.directives),
-        interfaces: sortNamed(t.interfaces),
-        fields: sortNamed(t.fields),
-      };
-    },
-    ScalarTypeDefinition(t) {
-      return { ...t, directives: sortNamed(t.directives) };
-    },
-    Document(t) {
-      return { ...t, definitions: sortNamed(t.definitions) };
-    },
-    FieldDefinition(t) {
-      return {
-        ...t,
-        directives: sortNamed(t.directives),
-        arguments: sortNamed(t.arguments),
-      };
-    },
-    Directive(t) {
-      return { ...t, arguments: sortNamed(t.arguments) };
-    },
-    EnumTypeDefinition(t) {
-      return { ...t, values: sortNamed(t.values) };
-    },
-    UnionTypeDefinition(t) {
-      return { ...t, types: sortNamed(t.types) };
-    },
-  });
-}
-
-type Named = { kind: Kind; name?: NameNode };
-
-function sortNamed<T extends Named>(arr?: readonly T[]): T[] | undefined {
-  if (arr == null) {
-    return arr;
-  }
-  return Array.from(arr).sort(sortByName);
-}
-
-function sortByName<T extends Named>(a: T, b: T): number {
-  // If both are unnamed, sort by kind
-  if (a.name == null && b.name == null) {
-    return a.kind.localeCompare(b.kind);
-  }
-  // Unnamed things go first
-  if (a.name == null) {
-    return -1;
-  }
-  if (b.name == null) {
-    return 1;
-  }
-
-  return a.name.value.localeCompare(b.name.value);
 }

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -1,7 +1,18 @@
-import { GraphQLSchema, printSchema } from "graphql";
+import {
+  DocumentNode,
+  GraphQLSchema,
+  print,
+  printSchema,
+  visit,
+  specifiedScalarTypes,
+  NameNode,
+  Kind,
+  FieldDefinitionNode,
+} from "graphql";
 import { ConfigOptions } from "./lib";
 import { codegen } from "./codegen";
 import { METADATA_DIRECTIVE_NAMES } from "./metadataDirectives";
+import { extend } from "./utils/helpers";
 
 /**
  * Prints code for a TypeScript module that exports a GraphQLSchema.
@@ -24,10 +35,10 @@ export function printExecutableSchema(
  * Includes the user-defined (or default) header comment if provided.
  */
 export function printGratsSDL(
-  schema: GraphQLSchema,
+  doc: DocumentNode,
   config: ConfigOptions,
 ): string {
-  const sdl = printSDLWithoutDirectives(schema);
+  const sdl = printSDLWithoutDirectives(doc);
 
   if (config.schemaHeader) {
     return `${config.schemaHeader}\n${sdl}`;
@@ -35,7 +46,33 @@ export function printGratsSDL(
   return sdl;
 }
 
-export function printSDLWithoutDirectives(schema: GraphQLSchema): string {
+export function printSDLWithoutDirectives(doc: DocumentNode): string {
+  const trimmed = visit(doc, {
+    DirectiveDefinition(t) {
+      if (METADATA_DIRECTIVE_NAMES.has(t.name.value)) {
+        return null;
+      }
+      return t;
+    },
+    Directive(t) {
+      if (METADATA_DIRECTIVE_NAMES.has(t.name.value)) {
+        return null;
+      }
+      return t;
+    },
+    ScalarTypeDefinition(t) {
+      if (specifiedScalarTypes.some((scalar) => scalar.name === t.name.value)) {
+        return null;
+      }
+      return t;
+    },
+  });
+  return print(sortDocument(mergeExtensions(trimmed)));
+}
+
+export function printSDLFromSchemaWithoutDirectives(
+  schema: GraphQLSchema,
+): string {
   return printSchema(
     new GraphQLSchema({
       ...schema.toConfig(),
@@ -44,4 +81,138 @@ export function printSDLWithoutDirectives(schema: GraphQLSchema): string {
       }),
     }),
   );
+}
+
+// Take every extension and merge it into the base type definition.
+function mergeExtensions(doc: DocumentNode): DocumentNode {
+  const fields = new MultiMap<string, FieldDefinitionNode>();
+  const sansExtensions = visit(doc, {
+    ObjectTypeExtension(t) {
+      if (t.directives != null || t.interfaces != null) {
+        throw new Error("Unexpected directives or interfaces on Extension");
+      }
+      fields.extend(t.name.value, t.fields);
+      return null;
+    },
+    InterfaceTypeExtension(t) {
+      if (t.directives != null || t.interfaces != null) {
+        throw new Error("Unexpected directives or interfaces on Extension");
+      }
+      fields.extend(t.name.value, t.fields);
+      return null;
+    },
+  });
+  return visit(sansExtensions, {
+    ObjectTypeDefinition(t) {
+      const extensions = fields.get(t.name.value);
+      if (t.fields == null) {
+        return { ...t, fields: extensions };
+      }
+      return { ...t, fields: [...t.fields, ...extensions] };
+    },
+    InterfaceTypeDefinition(t) {
+      const extensions = fields.get(t.name.value);
+      if (t.fields == null) {
+        return { ...t, fields: extensions };
+      }
+      return { ...t, fields: [...t.fields, ...extensions] };
+    },
+  });
+}
+
+class MultiMap<K, V> {
+  private readonly map = new Map<K, V[]>();
+
+  set(key: K, value: V): void {
+    let existing = this.map.get(key);
+    if (existing == null) {
+      existing = [];
+      this.map.set(key, existing);
+    }
+    existing.push(value);
+  }
+
+  extend(key: K, values?: readonly V[]): void {
+    if (values == null) {
+      return;
+    }
+    let existing = this.map.get(key);
+    if (existing == null) {
+      existing = [];
+      this.map.set(key, existing);
+    }
+    extend(existing, values);
+  }
+
+  get(key: K): V[] {
+    return this.map.get(key) ?? [];
+  }
+}
+
+function sortDocument(doc: DocumentNode): DocumentNode {
+  return visit(doc, {
+    ObjectTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        interfaces: sortNamed(t.interfaces),
+        fields: sortNamed(t.fields),
+      };
+    },
+    InterfaceTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        interfaces: sortNamed(t.interfaces),
+        fields: sortNamed(t.fields),
+      };
+    },
+    ScalarTypeDefinition(t) {
+      return { ...t, directives: sortNamed(t.directives) };
+    },
+    Document(t) {
+      return { ...t, definitions: sortNamed(t.definitions) };
+    },
+    FieldDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        arguments: sortNamed(t.arguments),
+      };
+    },
+    Directive(t) {
+      return { ...t, arguments: sortNamed(t.arguments) };
+    },
+    EnumTypeDefinition(t) {
+      return { ...t, values: sortNamed(t.values) };
+    },
+    UnionTypeDefinition(t) {
+      return { ...t, types: sortNamed(t.types) };
+    },
+  });
+}
+
+type Named = { kind: Kind; name?: NameNode };
+
+function sortNamed<T extends Named>(arr?: readonly T[]): T[] | undefined {
+  if (arr == null) {
+    return arr;
+  }
+  return Array.from(arr).sort(sortByName);
+}
+
+function sortByName<T extends Named>(a: T, b: T): number {
+  // If both are unnamed, sort by kind
+  if (a.name == null && b.name == null) {
+    return a.kind.localeCompare(b.kind);
+  }
+  // Unnamed things go first
+  if (a.name == null) {
+    return -1;
+  }
+  if (b.name == null) {
+    return 1;
+  }
+
+  return a.name.value.localeCompare(b.name.value);
 }

--- a/src/tests/fixtures/examples/playground.ts.expected
+++ b/src/tests/fixtures/examples/playground.ts.expected
@@ -40,7 +40,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  getUser: User @exported(tsModulePath: "grats/src/tests/fixtures/examples/playground.ts", functionName: "getUser", argCount: 1)
+  getUser: User @exported(argCount: 1, functionName: "getUser", tsModulePath: "grats/src/tests/fixtures/examples/playground.ts")
   me: User
   viewer: User @deprecated(reason: "Please use `me` instead.")
 }

--- a/src/tests/fixtures/examples/readme.ts.expected
+++ b/src/tests/fixtures/examples/readme.ts.expected
@@ -34,10 +34,6 @@ class UserResolver {
 OUTPUT
 -----------------
 -- SDL --
-schema {
-  query: Query
-}
-
 type Query {
   me: User @exported(tsModulePath: "grats/src/tests/fixtures/examples/readme.ts", functionName: "me", argCount: 1)
   viewer: User @deprecated(reason: "Please use `me` instead.") @exported(tsModulePath: "grats/src/tests/fixtures/examples/readme.ts", functionName: "viewer", argCount: 1)

--- a/src/tests/fixtures/examples/readme.ts.expected
+++ b/src/tests/fixtures/examples/readme.ts.expected
@@ -35,8 +35,8 @@ OUTPUT
 -----------------
 -- SDL --
 type Query {
-  me: User @exported(tsModulePath: "grats/src/tests/fixtures/examples/readme.ts", functionName: "me", argCount: 1)
-  viewer: User @deprecated(reason: "Please use `me` instead.") @exported(tsModulePath: "grats/src/tests/fixtures/examples/readme.ts", functionName: "viewer", argCount: 1)
+  me: User @exported(argCount: 1, functionName: "me", tsModulePath: "grats/src/tests/fixtures/examples/readme.ts")
+  viewer: User @deprecated(reason: "Please use `me` instead.") @exported(argCount: 1, functionName: "viewer", tsModulePath: "grats/src/tests/fixtures/examples/readme.ts")
 }
 
 """A user in our kick-ass system!"""

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts.expected
@@ -34,7 +34,7 @@ OUTPUT
 -----------------
 -- SDL --
 type Admin implements IPerson {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts")
   hello: String
 }
 
@@ -44,7 +44,7 @@ interface IPerson {
 }
 
 type User implements IPerson {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterface.ts")
   hello: String
 }
 -- TypeScript --

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts.expected
@@ -39,7 +39,7 @@ OUTPUT
 -----------------
 -- SDL --
 type Admin implements IPerson & IThing {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts")
 }
 
 interface IPerson implements IThing {
@@ -51,7 +51,7 @@ interface IThing {
 }
 
 type User implements IPerson & IThing {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_interface/addStringFieldToInterfaceImplementedByInterface.ts")
 }
 -- TypeScript --
 import { greeting as adminGreetingResolver } from "./addStringFieldToInterfaceImplementedByInterface";

--- a/src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts.expected
+++ b/src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts.expected
@@ -37,6 +37,15 @@ class Admin implements IPerson {
 -----------------
 OUTPUT
 -----------------
+src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:9:17 - error: Field "Admin.greeting" can only be defined once.
+
+9 export function greeting(person: IPerson): string {
+                  ~~~~~~~~
+
+  src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:13:5
+    13 /** @gqlField greeting */
+           ~~~~~~~~~~~~~~~~~~~
+    Related location
 src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:9:17 - error: Field "IPerson.greeting" can only be defined once.
 
 9 export function greeting(person: IPerson): string {
@@ -47,15 +56,6 @@ src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:9:
            ~~~~~~~~~~~~~~~~~~~
     Related location
 src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:9:17 - error: Field "User.greeting" can only be defined once.
-
-9 export function greeting(person: IPerson): string {
-                  ~~~~~~~~
-
-  src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:13:5
-    13 /** @gqlField greeting */
-           ~~~~~~~~~~~~~~~~~~~
-    Related location
-src/tests/fixtures/extend_interface/addStringFieldToInterfaceTwice.invalid.ts:9:17 - error: Field "Admin.greeting" can only be defined once.
 
 9 export function greeting(person: IPerson): string {
                   ~~~~~~~~

--- a/src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts.expected
+++ b/src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts.expected
@@ -29,12 +29,12 @@ class User implements IPerson {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts:9:17 - error: Field "User.greeting" can only be defined once.
+src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts:21:3 - error: Field "User.greeting" can only be defined once.
 
-9 export function greeting(person: IPerson): string {
-                  ~~~~~~~~
+21   greeting(): string {
+     ~~~~~~~~
 
-  src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts:21:3
-    21   greeting(): string {
-         ~~~~~~~~
+  src/tests/fixtures/extend_interface/redefineFiledThatExistsOnConcreteType.invalid.ts:9:17
+    9 export function greeting(person: IPerson): string {
+                      ~~~~~~~~
     Related location

--- a/src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts.expected
+++ b/src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts.expected
@@ -27,12 +27,12 @@ interface User extends IPerson {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts:9:17 - error: Field "User.greeting" can only be defined once.
+src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts:21:3 - error: Field "User.greeting" can only be defined once.
 
-9 export function greeting(person: IPerson): string {
-                  ~~~~~~~~
+21   greeting(): string;
+     ~~~~~~~~
 
-  src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts:21:3
-    21   greeting(): string;
-         ~~~~~~~~
+  src/tests/fixtures/extend_interface/redefineFiledThatExistsOnImplementingInterface.invalid.ts:9:17
+    9 export function greeting(person: IPerson): string {
+                      ~~~~~~~~
     Related location

--- a/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
+++ b/src/tests/fixtures/extend_type/addDeprecatedField.ts.expected
@@ -19,7 +19,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  greeting: String @deprecated(reason: "Because reasons") @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/addDeprecatedField.ts", functionName: "greeting", argCount: 1)
+  greeting: String @deprecated(reason: "Because reasons") @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/addDeprecatedField.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./addDeprecatedField";

--- a/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithArguments.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  greeting(name: String!): String @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithArguments.ts", functionName: "greeting", argCount: 2)
+  greeting(name: String!): String @exported(argCount: 2, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithArguments.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./addFieldWithArguments";

--- a/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
+++ b/src/tests/fixtures/extend_type/addFieldWithDescription.ts.expected
@@ -20,7 +20,7 @@ OUTPUT
 -- SDL --
 type SomeType {
   """Best field ever!"""
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithDescription.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/addFieldWithDescription.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./addFieldWithDescription";

--- a/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  hello: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts", functionName: "greeting", argCount: 1)
+  hello: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/addRenamedFieldToSomeType.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./addRenamedFieldToSomeType";

--- a/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
+++ b/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts.expected
@@ -16,7 +16,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/addStringFieldToSomeType.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./addStringFieldToSomeType";

--- a/src/tests/fixtures/extend_type/optionalModelType.ts.expected
+++ b/src/tests/fixtures/extend_type/optionalModelType.ts.expected
@@ -23,7 +23,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/extend_type/optionalModelType.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/extend_type/optionalModelType.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./optionalModelType";

--- a/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts.expected
@@ -21,11 +21,11 @@ type MyInputType = {
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts:10:16 - error: The type of MyType.someField must be Output Type but got: MyInputType.
-
-10   someField(): MyInputType;
-                  ~~~~~~~~~~~
 src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts:15:14 - error: The type of MyInputType.someField must be Input Type but got: MyType!.
 
 15   someField: MyType;
                 ~~~~~~
+src/tests/fixtures/input_types/InputTypeReturnedFromField.invalid.ts:10:16 - error: The type of MyType.someField must be Output Type but got: MyInputType.
+
+10   someField(): MyInputType;
+                  ~~~~~~~~~~~

--- a/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
+++ b/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts.expected
@@ -18,7 +18,7 @@ OUTPUT
 -----------------
 -- SDL --
 type User {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts", functionName: "greeting", argCount: 3)
+  greeting: String @exported(argCount: 3, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/resolver_context/FunctionWithContextValue.ts")
 }
 -- TypeScript --
 import { greeting as userGreetingResolver } from "./FunctionWithContextValue";

--- a/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
+++ b/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
@@ -14,12 +14,8 @@ export async function* greetings(_: Subscription): AsyncIterable<string> {
 OUTPUT
 -----------------
 -- SDL --
-schema {
-  subscription: Subscription
-}
-
 type Subscription {
-  greetings: String @exported(tsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts", functionName: "greetings", argCount: 1) @asyncIterable
+  greetings: String @asyncIterable @exported(tsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts", functionName: "greetings", argCount: 1)
 }
 -- TypeScript --
 import { greetings as subscriptionGreetingsResolver } from "./SubscriptionFunctionFieldWithAsyncIterable";

--- a/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
+++ b/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts.expected
@@ -15,7 +15,7 @@ OUTPUT
 -----------------
 -- SDL --
 type Subscription {
-  greetings: String @asyncIterable @exported(tsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts", functionName: "greetings", argCount: 1)
+  greetings: String @asyncIterable @exported(argCount: 1, functionName: "greetings", tsModulePath: "grats/src/tests/fixtures/subscriptions/SubscriptionFunctionFieldWithAsyncIterable.ts")
 }
 -- TypeScript --
 import { greetings as subscriptionGreetingsResolver } from "./SubscriptionFunctionFieldWithAsyncIterable";

--- a/src/tests/fixtures/todo/userExample.ts.expected
+++ b/src/tests/fixtures/todo/userExample.ts.expected
@@ -27,12 +27,12 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  me: User @exported(tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts", functionName: "me", argCount: 1)
+  me: User @exported(argCount: 1, functionName: "me", tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts")
 }
 
 type User {
   firstName: String
-  fullName: String @exported(tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts", functionName: "fullName", argCount: 1)
+  fullName: String @exported(argCount: 1, functionName: "fullName", tsModulePath: "grats/src/tests/fixtures/todo/userExample.ts")
   lastName: String
 }
 -- TypeScript --

--- a/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 -- SDL --
 type SomeType {
-  greeting: String @exported(tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts", functionName: "greeting", argCount: 1)
+  greeting: String @exported(argCount: 1, functionName: "greeting", tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/AliasOfUnknownDefinesType.ts")
 }
 -- TypeScript --
 import { greeting as someTypeGreetingResolver } from "./AliasOfUnknownDefinesType";

--- a/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts.expected
@@ -14,7 +14,7 @@ OUTPUT
 -----------------
 -- SDL --
 type Query {
-  foo: String @exported(tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts", functionName: "foo", argCount: 1)
+  foo: String @exported(argCount: 1, functionName: "foo", tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts")
 }
 -- TypeScript --
 import { foo as queryFooResolver } from "./QueryAsAliasOfUnknown";

--- a/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts.expected
+++ b/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts.expected
@@ -13,10 +13,6 @@ export function foo(_: Query): string {
 OUTPUT
 -----------------
 -- SDL --
-schema {
-  query: Query
-}
-
 type Query {
   foo: String @exported(tsModulePath: "grats/src/tests/fixtures/type_definitions_from_alias/QueryAsAliasOfUnknown.ts", functionName: "foo", argCount: 1)
 }

--- a/src/tests/fixtures/typename/UnionMemberMissingTypename.ts.expected
+++ b/src/tests/fixtures/typename/UnionMemberMissingTypename.ts.expected
@@ -19,11 +19,11 @@ export type MyUnion = User | Group;
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/typename/UnionMemberMissingTypename.ts:2:14 - error: Missing __typename on `User`. The type `MyUnion` is used in a union or interface, so it must have a `__typename` field.
-
-2 export class User {
-               ~~~~
 src/tests/fixtures/typename/UnionMemberMissingTypename.ts:8:14 - error: Missing __typename on `Group`. The type `MyUnion` is used in a union or interface, so it must have a `__typename` field.
 
 8 export class Group {
                ~~~~~
+src/tests/fixtures/typename/UnionMemberMissingTypename.ts:2:14 - error: Missing __typename on `User`. The type `MyUnion` is used in a union or interface, so it must have a `__typename` field.
+
+2 export class User {
+               ~~~~

--- a/src/transforms/applyDefaultNullability.ts
+++ b/src/transforms/applyDefaultNullability.ts
@@ -8,6 +8,10 @@ import { GraphQLConstructor } from "../GraphQLConstructor";
 import { ConfigOptions } from "../gratsConfig";
 import { loc } from "../utils/helpers";
 
+/**
+ * Grats has options to make all fields nullable by default to conform to
+ * GraphQL best practices. This transform applies this option to the schema.
+ */
 export function applyDefaultNullability(
   doc: DocumentNode,
   { nullableByDefault }: ConfigOptions,

--- a/src/transforms/mergeExtensions.ts
+++ b/src/transforms/mergeExtensions.ts
@@ -1,0 +1,68 @@
+import { DocumentNode, FieldDefinitionNode, visit } from "graphql";
+import { extend } from "../utils/helpers";
+
+// Take every extension and merge it into the base type definition.
+export function mergeExtensions(doc: DocumentNode): DocumentNode {
+  const fields = new MultiMap<string, FieldDefinitionNode>();
+  const sansExtensions = visit(doc, {
+    ObjectTypeExtension(t) {
+      if (t.directives != null || t.interfaces != null) {
+        throw new Error("Unexpected directives or interfaces on Extension");
+      }
+      fields.extend(t.name.value, t.fields);
+      return null;
+    },
+    InterfaceTypeExtension(t) {
+      if (t.directives != null || t.interfaces != null) {
+        throw new Error("Unexpected directives or interfaces on Extension");
+      }
+      fields.extend(t.name.value, t.fields);
+      return null;
+    },
+  });
+  return visit(sansExtensions, {
+    ObjectTypeDefinition(t) {
+      const extensions = fields.get(t.name.value);
+      if (t.fields == null) {
+        return { ...t, fields: extensions };
+      }
+      return { ...t, fields: [...t.fields, ...extensions] };
+    },
+    InterfaceTypeDefinition(t) {
+      const extensions = fields.get(t.name.value);
+      if (t.fields == null) {
+        return { ...t, fields: extensions };
+      }
+      return { ...t, fields: [...t.fields, ...extensions] };
+    },
+  });
+}
+
+class MultiMap<K, V> {
+  private readonly map = new Map<K, V[]>();
+
+  set(key: K, value: V): void {
+    let existing = this.map.get(key);
+    if (existing == null) {
+      existing = [];
+      this.map.set(key, existing);
+    }
+    existing.push(value);
+  }
+
+  extend(key: K, values?: readonly V[]): void {
+    if (values == null) {
+      return;
+    }
+    let existing = this.map.get(key);
+    if (existing == null) {
+      existing = [];
+      this.map.set(key, existing);
+    }
+    extend(existing, values);
+  }
+
+  get(key: K): V[] {
+    return this.map.get(key) ?? [];
+  }
+}

--- a/src/transforms/sortSchemaAst.ts
+++ b/src/transforms/sortSchemaAst.ts
@@ -1,0 +1,70 @@
+import { DocumentNode, Kind, NameNode, visit } from "graphql";
+
+export function sortSchemaAst(doc: DocumentNode): DocumentNode {
+  return visit(doc, {
+    ObjectTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        interfaces: sortNamed(t.interfaces),
+        fields: sortNamed(t.fields),
+      };
+    },
+    InterfaceTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        interfaces: sortNamed(t.interfaces),
+        fields: sortNamed(t.fields),
+      };
+    },
+    ScalarTypeDefinition(t) {
+      return { ...t, directives: sortNamed(t.directives) };
+    },
+    Document(t) {
+      return { ...t, definitions: sortNamed(t.definitions) };
+    },
+    FieldDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        arguments: sortNamed(t.arguments),
+      };
+    },
+    Directive(t) {
+      return t;
+      return { ...t, arguments: sortNamed(t.arguments) };
+    },
+    EnumTypeDefinition(t) {
+      return { ...t, values: sortNamed(t.values) };
+    },
+    UnionTypeDefinition(t) {
+      return { ...t, types: sortNamed(t.types) };
+    },
+  });
+}
+
+type Named = { kind: Kind; name?: NameNode };
+
+function sortNamed<T extends Named>(arr?: readonly T[]): T[] | undefined {
+  if (arr == null) {
+    return arr;
+  }
+  return Array.from(arr).sort(sortByName);
+}
+
+function sortByName<T extends Named>(a: T, b: T): number {
+  // If both are unnamed, sort by kind
+  if (a.name == null && b.name == null) {
+    return a.kind.localeCompare(b.kind);
+  }
+  // Unnamed things go first
+  if (a.name == null) {
+    return -1;
+  }
+  if (b.name == null) {
+    return 1;
+  }
+
+  return a.name.value.localeCompare(b.name.value);
+}

--- a/src/transforms/sortSchemaAst.ts
+++ b/src/transforms/sortSchemaAst.ts
@@ -1,7 +1,17 @@
 import { DocumentNode, Kind, NameNode, visit } from "graphql";
+import { naturalCompare } from "../utils/naturalCompare";
 
+/*
+ * Similar to lexicographicSortSchema from graphql-js but applied against an AST
+ * instead of a `GraphQLSchema`. Note that this creates some subtle differences,
+ * such as the presence of schema directives, which are not preserved in a
+ * `GraphQLSchema`.
+ */
 export function sortSchemaAst(doc: DocumentNode): DocumentNode {
   return visit(doc, {
+    ScalarTypeDefinition(t) {
+      return { ...t, directives: sortNamed(t.directives) };
+    },
     ObjectTypeDefinition(t) {
       return {
         ...t,
@@ -18,8 +28,26 @@ export function sortSchemaAst(doc: DocumentNode): DocumentNode {
         fields: sortNamed(t.fields),
       };
     },
-    ScalarTypeDefinition(t) {
-      return { ...t, directives: sortNamed(t.directives) };
+    UnionTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        types: sortNamed(t.types),
+      };
+    },
+    EnumTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        values: sortNamed(t.values),
+      };
+    },
+    InputObjectTypeDefinition(t) {
+      return {
+        ...t,
+        directives: sortNamed(t.directives),
+        fields: sortNamed(t.fields),
+      };
     },
     Document(t) {
       return { ...t, definitions: sortNamed(t.definitions) };
@@ -31,32 +59,36 @@ export function sortSchemaAst(doc: DocumentNode): DocumentNode {
         arguments: sortNamed(t.arguments),
       };
     },
+    InputValueDefinition(t) {
+      return { ...t, directives: sortNamed(t.directives) };
+    },
     Directive(t) {
-      return t;
       return { ...t, arguments: sortNamed(t.arguments) };
-    },
-    EnumTypeDefinition(t) {
-      return { ...t, values: sortNamed(t.values) };
-    },
-    UnionTypeDefinition(t) {
-      return { ...t, types: sortNamed(t.types) };
     },
   });
 }
 
 type Named = { kind: Kind; name?: NameNode };
 
+// Given an optional array of AST nodes, sort them by name or kind.
 function sortNamed<T extends Named>(arr?: readonly T[]): T[] | undefined {
   if (arr == null) {
     return arr;
   }
-  return Array.from(arr).sort(sortByName);
+  return Array.from(arr).sort(compareByName);
 }
 
-function sortByName<T extends Named>(a: T, b: T): number {
+// Note that we use `naturalCompare` here instead of `localeCompare`. This has
+// three motivations:
+//
+// * It matches the behavior of `lexicographicSortSchema` from graphql-js.
+// * It's stable across locales so users in different locales won't generate
+//   different outputs from the same input resulting in unnecessary diffs.
+// * It's likely a more user-friendly sort order than simple > or <.
+function compareByName<T extends Named>(a: T, b: T): number {
   // If both are unnamed, sort by kind
   if (a.name == null && b.name == null) {
-    return a.kind.localeCompare(b.kind);
+    return naturalCompare(a.kind, b.kind);
   }
   // Unnamed things go first
   if (a.name == null) {
@@ -66,5 +98,5 @@ function sortByName<T extends Named>(a: T, b: T): number {
     return 1;
   }
 
-  return a.name.value.localeCompare(b.name.value);
+  return naturalCompare(a.name.value, b.name.value);
 }

--- a/src/utils/naturalCompare.ts
+++ b/src/utils/naturalCompare.ts
@@ -1,0 +1,60 @@
+/**
+ * Returns a number indicating whether a reference string comes before, or after,
+ * or is the same as the given string in natural sort order.
+ *
+ * See: https://en.wikipedia.org/wiki/Natural_sort_order
+ *
+ * ~~Stolen~~ Borrowed from:
+ * https://github.com/graphql/graphql-js/blob/2aedf25e157d1d1c8fdfeaa4c0d2f3d9d3457dba/src/jsutils/naturalCompare.ts
+ */
+export function naturalCompare(aStr: string, bStr: string): number {
+  let aIndex = 0;
+  let bIndex = 0;
+
+  while (aIndex < aStr.length && bIndex < bStr.length) {
+    let aChar = aStr.charCodeAt(aIndex);
+    let bChar = bStr.charCodeAt(bIndex);
+
+    if (isDigit(aChar) && isDigit(bChar)) {
+      let aNum = 0;
+      do {
+        ++aIndex;
+        aNum = aNum * 10 + aChar - DIGIT_0;
+        aChar = aStr.charCodeAt(aIndex);
+      } while (isDigit(aChar) && aNum > 0);
+
+      let bNum = 0;
+      do {
+        ++bIndex;
+        bNum = bNum * 10 + bChar - DIGIT_0;
+        bChar = bStr.charCodeAt(bIndex);
+      } while (isDigit(bChar) && bNum > 0);
+
+      if (aNum < bNum) {
+        return -1;
+      }
+
+      if (aNum > bNum) {
+        return 1;
+      }
+    } else {
+      if (aChar < bChar) {
+        return -1;
+      }
+      if (aChar > bChar) {
+        return 1;
+      }
+      ++aIndex;
+      ++bIndex;
+    }
+  }
+
+  return aStr.length - bStr.length;
+}
+
+const DIGIT_0 = 48;
+const DIGIT_9 = 57;
+
+function isDigit(code: number): boolean {
+  return !isNaN(code) && DIGIT_0 <= code && code <= DIGIT_9;
+}

--- a/website/docs/04-docblock-tags/snippets/02-property-and-method.out
+++ b/website/docs/04-docblock-tags/snippets/02-property-and-method.out
@@ -15,7 +15,6 @@ class User {
 === SNIP ===
 type User {
   myField: String
-
   """A description of some field."""
   someField: String
 }

--- a/website/scripts/gratsCode.js
+++ b/website/scripts/gratsCode.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
-const { buildSchemaResult, codegen } = require("grats");
-const { printSDLWithoutDirectives } = require("grats");
+const { buildSchemaAndDocResult, codegen } = require("grats");
+const { printSDLWithoutMetadata } = require("grats");
 const glob = require("glob");
 
 async function main() {
@@ -29,16 +29,16 @@ function processFile(file) {
     errors: [],
     fileNames: files,
   };
-  const schemaResult = buildSchemaResult(parsedOptions);
-  if (schemaResult.kind === "ERROR") {
-    const errors = schemaResult.err.formatDiagnosticsWithContext();
+  const schemaAndDocResult = buildSchemaAndDocResult(parsedOptions);
+  if (schemaAndDocResult.kind === "ERROR") {
+    const errors = schemaAndDocResult.err.formatDiagnosticsWithContext();
     console.error(errors);
     throw new Error("Invalid grats code");
   }
 
-  const schema = schemaResult.value;
+  const { doc, schema } = schemaAndDocResult.value;
   const typeScript = codegen(schema, file, options);
-  const graphql = printSDLWithoutDirectives(schema);
+  const graphql = printSDLWithoutMetadata(doc);
 
   const fileContent = fs.readFileSync(file, "utf8");
 


### PR DESCRIPTION
This gives us more control over the SDL we emit. Specifically, it allows us to preserve server directives which will likely be useful for other things, for example: https://github.com/captbaritone/grats/pull/96