### PR TITLE
Apply runtime checks for semantic nullability to shore up type-holes

### DIFF
--- a/examples/strict-semantic-nullability/Subscription.ts
+++ b/examples/strict-semantic-nullability/Subscription.ts
@@ -13,3 +13,19 @@ export async function* countdown(
     yield i;
   }
 }
+
+// All of these should result in an error. Used for validating semantic nullability runtime validation.
+
+/** @gqlField */
+export async function* nullItems(_: Subscription): AsyncIterable<string> {
+  const empty: string[] = [];
+  while (true) {
+    yield empty[0];
+  }
+}
+
+/** @gqlField */
+export function nullIterable(_: Subscription): AsyncIterable<string> {
+  // @ts-ignore
+  return null;
+}

--- a/examples/strict-semantic-nullability/schema.graphql
+++ b/examples/strict-semantic-nullability/schema.graphql
@@ -18,6 +18,8 @@ type Query {
 
 type Subscription {
   countdown(from: Int!): Int @semanticNonNull
+  nullItems: String @semanticNonNull
+  nullIterable: String @semanticNonNull
 }
 
 type User implements IPerson {

--- a/examples/strict-semantic-nullability/schema.ts
+++ b/examples/strict-semantic-nullability/schema.ts
@@ -6,7 +6,15 @@ import { allUsers as queryAllUsersResolver } from "./models/User";
 import { me as queryMeResolver } from "./Query";
 import { person as queryPersonResolver } from "./Query";
 import { countdown as subscriptionCountdownResolver } from "./Subscription";
-import { GraphQLSchema, GraphQLObjectType, GraphQLList, GraphQLNonNull, GraphQLString, GraphQLInterfaceType, GraphQLInt } from "graphql";
+import { nullItems as subscriptionNullItemsResolver } from "./Subscription";
+import { nullIterable as subscriptionNullIterableResolver } from "./Subscription";
+import { GraphQLSchema, GraphQLObjectType, GraphQLList, GraphQLNonNull, GraphQLString, defaultFieldResolver, GraphQLInterfaceType, GraphQLInt } from "graphql";
+async function assertNonNull<T>(value: T | Promise<T>): Promise<T> {
+    const awaited = await value;
+    if (awaited == null)
+        throw new Error("Cannot return null for semantically non-nullable field.");
+    return awaited;
+}
 export function getSchema(): GraphQLSchema {
     const GroupType: GraphQLObjectType = new GraphQLObjectType({
         name: "Group",
@@ -14,15 +22,24 @@ export function getSchema(): GraphQLSchema {
             return {
                 description: {
                     name: "description",
-                    type: GraphQLString
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 },
                 members: {
                     name: "members",
-                    type: new GraphQLList(new GraphQLNonNull(UserType))
+                    type: new GraphQLList(new GraphQLNonNull(UserType)),
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 },
                 name: {
                     name: "name",
-                    type: GraphQLString
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 }
             };
         }
@@ -44,11 +61,17 @@ export function getSchema(): GraphQLSchema {
             return {
                 groups: {
                     name: "groups",
-                    type: new GraphQLList(new GraphQLNonNull(GroupType))
+                    type: new GraphQLList(new GraphQLNonNull(GroupType)),
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 },
                 name: {
                     name: "name",
-                    type: GraphQLString
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 }
             };
         },
@@ -64,21 +87,21 @@ export function getSchema(): GraphQLSchema {
                     name: "allUsers",
                     type: new GraphQLList(new GraphQLNonNull(UserType)),
                     resolve(source) {
-                        return queryAllUsersResolver(source);
+                        return assertNonNull(queryAllUsersResolver(source));
                     }
                 },
                 me: {
                     name: "me",
                     type: UserType,
                     resolve(source) {
-                        return queryMeResolver(source);
+                        return assertNonNull(queryMeResolver(source));
                     }
                 },
                 person: {
                     name: "person",
                     type: IPersonType,
                     resolve(source) {
-                        return queryPersonResolver(source);
+                        return assertNonNull(queryPersonResolver(source));
                     }
                 }
             };
@@ -101,7 +124,27 @@ export function getSchema(): GraphQLSchema {
                         return subscriptionCountdownResolver(source, args);
                     },
                     resolve(payload) {
-                        return payload;
+                        return assertNonNull(payload);
+                    }
+                },
+                nullItems: {
+                    name: "nullItems",
+                    type: GraphQLString,
+                    subscribe(source) {
+                        return subscriptionNullItemsResolver(source);
+                    },
+                    resolve(payload) {
+                        return assertNonNull(payload);
+                    }
+                },
+                nullIterable: {
+                    name: "nullIterable",
+                    type: GraphQLString,
+                    subscribe(source) {
+                        return subscriptionNullIterableResolver(source);
+                    },
+                    resolve(payload) {
+                        return assertNonNull(payload);
                     }
                 }
             };

--- a/src/codegenHelpers.ts
+++ b/src/codegenHelpers.ts
@@ -1,0 +1,70 @@
+import * as ts from "typescript";
+
+export const ASSERT_NON_NULL_HELPER = "assertNonNull";
+const F = ts.factory;
+
+/**
+ * async function assertNonNull<T>(value: T | Promise<T>): Promise<T> {
+ *   const awaited = await value;
+ *   if (awaited == null)
+ *     throw new Error("Cannot return null for semantically non-nullable field.");
+ *   return awaited;
+ * }
+ */
+export function createAssertNonNullHelper(): ts.FunctionDeclaration {
+  const argName = "value";
+  const awaited = "awaited";
+  const t = "T";
+  const tReference = F.createTypeReferenceNode("T");
+  const promiseT = F.createTypeReferenceNode("Promise", [tReference]);
+
+  const typeParam = F.createUnionTypeNode([tReference, promiseT]);
+
+  return F.createFunctionDeclaration(
+    [F.createModifier(ts.SyntaxKind.AsyncKeyword)],
+    undefined,
+    ASSERT_NON_NULL_HELPER,
+    [F.createTypeParameterDeclaration(undefined, t)],
+    [
+      F.createParameterDeclaration(
+        undefined,
+        undefined,
+        argName,
+        undefined,
+        typeParam,
+        undefined,
+      ),
+    ],
+    promiseT,
+    F.createBlock(
+      [
+        F.createVariableStatement(
+          undefined,
+          F.createVariableDeclarationList(
+            [
+              F.createVariableDeclaration(
+                awaited,
+                undefined,
+                undefined,
+                F.createAwaitExpression(F.createIdentifier(argName)),
+              ),
+            ],
+            ts.NodeFlags.Const,
+          ),
+        ),
+        F.createIfStatement(
+          F.createEquality(F.createIdentifier(awaited), F.createNull()),
+          F.createThrowStatement(
+            F.createNewExpression(F.createIdentifier("Error"), undefined, [
+              F.createStringLiteral(
+                "Cannot return null for semantically non-nullable field.",
+              ),
+            ]),
+          ),
+        ),
+        F.createReturnStatement(F.createIdentifier(awaited)),
+      ],
+      true,
+    ),
+  );
+}

--- a/src/tests/fixtures/semantic_nullability/semanticNonNull.ts.expected
+++ b/src/tests/fixtures/semantic_nullability/semanticNonNull.ts.expected
@@ -60,7 +60,13 @@ The `level` argument can be used to indicate what level is semantically non null
 """
 directive @semanticNonNull(field: String = null, level: Int = null) repeatable on FIELD_DEFINITION | OBJECT
 -- TypeScript --
-import { GraphQLSchema, GraphQLObjectType, GraphQLString } from "graphql";
+import { GraphQLSchema, GraphQLObjectType, GraphQLString, defaultFieldResolver } from "graphql";
+async function assertNonNull<T>(value: T | Promise<T>): Promise<T> {
+    const awaited = await value;
+    if (awaited == null)
+        throw new Error("Cannot return null for semantically non-nullable field.");
+    return awaited;
+}
 export function getSchema(): GraphQLSchema {
     const UserType: GraphQLObjectType = new GraphQLObjectType({
         name: "User",
@@ -68,7 +74,10 @@ export function getSchema(): GraphQLSchema {
             return {
                 name: {
                     name: "name",
-                    type: GraphQLString
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 }
             };
         }

--- a/src/tests/fixtures/semantic_nullability/semanticNonNullMatchesInterface.ts.expected
+++ b/src/tests/fixtures/semantic_nullability/semanticNonNullMatchesInterface.ts.expected
@@ -71,7 +71,13 @@ The `level` argument can be used to indicate what level is semantically non null
 """
 directive @semanticNonNull(field: String = null, level: Int = null) repeatable on FIELD_DEFINITION | OBJECT
 -- TypeScript --
-import { GraphQLSchema, GraphQLInterfaceType, GraphQLString, GraphQLObjectType } from "graphql";
+import { GraphQLSchema, GraphQLInterfaceType, GraphQLString, GraphQLObjectType, defaultFieldResolver } from "graphql";
+async function assertNonNull<T>(value: T | Promise<T>): Promise<T> {
+    const awaited = await value;
+    if (awaited == null)
+        throw new Error("Cannot return null for semantically non-nullable field.");
+    return awaited;
+}
 export function getSchema(): GraphQLSchema {
     const IPersonType: GraphQLInterfaceType = new GraphQLInterfaceType({
         name: "IPerson",
@@ -90,7 +96,10 @@ export function getSchema(): GraphQLSchema {
             return {
                 name: {
                     name: "name",
-                    type: GraphQLString
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
                 }
             };
         },

--- a/src/tests/integrationFixtures/strictSemanticNullability/index.ts
+++ b/src/tests/integrationFixtures/strictSemanticNullability/index.ts
@@ -1,0 +1,65 @@
+// { "strictSemanticNullability": true }
+
+import { Int } from "../../..";
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField */
+export function actuallyReturnsNull(_: Query): string {
+  const empty: string[] = [];
+  return empty[0]; // Oops!
+}
+
+/** @gqlField */
+export async function actuallyReturnsAsyncNull(_: Query): Promise<string> {
+  const empty: string[] = [];
+  return empty[0]; // Oops!
+}
+
+/** @gqlField */
+export function me(_: Query): User {
+  const empty: string[] = [];
+  return new User(empty[0]);
+}
+
+/** @gqlInterface */
+interface IPerson {
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlType */
+class User implements IPerson {
+  __typename = "User";
+  constructor(name: string) {
+    this.name = name;
+    this.alsoName = name;
+  }
+  /** @gqlField */
+  name: string;
+
+  /** @gqlField notName */
+  alsoName: string;
+}
+
+/** @gqlType */
+type Subscription = unknown;
+
+/** @gqlField */
+export async function* names(_: Subscription): AsyncIterable<string> {
+  const empty: string[] = [];
+  yield empty[0]; // Oops!
+}
+
+// All of these should result in an error
+export const query = `
+  query {
+    actuallyReturnsNull
+    actuallyReturnsAsyncNull
+    me {
+      name
+      notName
+    }
+  }
+`;

--- a/src/tests/integrationFixtures/strictSemanticNullability/index.ts.expected
+++ b/src/tests/integrationFixtures/strictSemanticNullability/index.ts.expected
@@ -1,0 +1,134 @@
+-----------------
+INPUT
+----------------- 
+// { "strictSemanticNullability": true }
+
+import { Int } from "../../..";
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField */
+export function actuallyReturnsNull(_: Query): string {
+  const empty: string[] = [];
+  return empty[0]; // Oops!
+}
+
+/** @gqlField */
+export async function actuallyReturnsAsyncNull(_: Query): Promise<string> {
+  const empty: string[] = [];
+  return empty[0]; // Oops!
+}
+
+/** @gqlField */
+export function me(_: Query): User {
+  const empty: string[] = [];
+  return new User(empty[0]);
+}
+
+/** @gqlInterface */
+interface IPerson {
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlType */
+class User implements IPerson {
+  __typename = "User";
+  constructor(name: string) {
+    this.name = name;
+    this.alsoName = name;
+  }
+  /** @gqlField */
+  name: string;
+
+  /** @gqlField notName */
+  alsoName: string;
+}
+
+/** @gqlType */
+type Subscription = unknown;
+
+/** @gqlField */
+export async function* names(_: Subscription): AsyncIterable<string> {
+  const empty: string[] = [];
+  yield empty[0]; // Oops!
+}
+
+// All of these should result in an error
+export const query = `
+  query {
+    actuallyReturnsNull
+    actuallyReturnsAsyncNull
+    me {
+      name
+      notName
+    }
+  }
+`;
+
+-----------------
+OUTPUT
+-----------------
+{
+  "errors": [
+    {
+      "message": "Cannot return null for semantically non-nullable field.",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "actuallyReturnsNull"
+      ]
+    },
+    {
+      "message": "Cannot return null for semantically non-nullable field.",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "actuallyReturnsAsyncNull"
+      ]
+    },
+    {
+      "message": "Cannot return null for semantically non-nullable field.",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "me",
+        "name"
+      ]
+    },
+    {
+      "message": "Cannot return null for semantically non-nullable field.",
+      "locations": [
+        {
+          "line": 7,
+          "column": 7
+        }
+      ],
+      "path": [
+        "me",
+        "notName"
+      ]
+    }
+  ],
+  "data": {
+    "actuallyReturnsNull": null,
+    "actuallyReturnsAsyncNull": null,
+    "me": {
+      "name": null,
+      "notName": null
+    }
+  }
+}

--- a/src/tests/integrationFixtures/strictSemanticNullability/schema.ts
+++ b/src/tests/integrationFixtures/strictSemanticNullability/schema.ts
@@ -1,0 +1,98 @@
+import { actuallyReturnsAsyncNull as queryActuallyReturnsAsyncNullResolver } from "./index";
+import { actuallyReturnsNull as queryActuallyReturnsNullResolver } from "./index";
+import { me as queryMeResolver } from "./index";
+import { names as subscriptionNamesResolver } from "./index";
+import { GraphQLSchema, GraphQLObjectType, GraphQLString, defaultFieldResolver, GraphQLInterfaceType } from "graphql";
+async function assertNonNull<T>(value: T | Promise<T>): Promise<T> {
+    const awaited = await value;
+    if (awaited == null)
+        throw new Error("Cannot return null for semantically non-nullable field.");
+    return awaited;
+}
+export function getSchema(): GraphQLSchema {
+    const IPersonType: GraphQLInterfaceType = new GraphQLInterfaceType({
+        name: "IPerson",
+        fields() {
+            return {
+                name: {
+                    name: "name",
+                    type: GraphQLString
+                }
+            };
+        }
+    });
+    const UserType: GraphQLObjectType = new GraphQLObjectType({
+        name: "User",
+        fields() {
+            return {
+                name: {
+                    name: "name",
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(defaultFieldResolver(source, args, context, info));
+                    }
+                },
+                notName: {
+                    name: "notName",
+                    type: GraphQLString,
+                    resolve(source, args, context, info) {
+                        return assertNonNull(typeof source.alsoName === "function" ? source.alsoName(source, args, context, info) : source.alsoName);
+                    }
+                }
+            };
+        },
+        interfaces() {
+            return [IPersonType];
+        }
+    });
+    const QueryType: GraphQLObjectType = new GraphQLObjectType({
+        name: "Query",
+        fields() {
+            return {
+                actuallyReturnsAsyncNull: {
+                    name: "actuallyReturnsAsyncNull",
+                    type: GraphQLString,
+                    resolve(source) {
+                        return assertNonNull(queryActuallyReturnsAsyncNullResolver(source));
+                    }
+                },
+                actuallyReturnsNull: {
+                    name: "actuallyReturnsNull",
+                    type: GraphQLString,
+                    resolve(source) {
+                        return assertNonNull(queryActuallyReturnsNullResolver(source));
+                    }
+                },
+                me: {
+                    name: "me",
+                    type: UserType,
+                    resolve(source) {
+                        return assertNonNull(queryMeResolver(source));
+                    }
+                }
+            };
+        }
+    });
+    const SubscriptionType: GraphQLObjectType = new GraphQLObjectType({
+        name: "Subscription",
+        fields() {
+            return {
+                names: {
+                    name: "names",
+                    type: GraphQLString,
+                    subscribe(source) {
+                        return subscriptionNamesResolver(source);
+                    },
+                    resolve(payload) {
+                        return assertNonNull(payload);
+                    }
+                }
+            };
+        }
+    });
+    return new GraphQLSchema({
+        query: QueryType,
+        subscription: SubscriptionType,
+        types: [IPersonType, QueryType, SubscriptionType, UserType]
+    });
+}


### PR DESCRIPTION
With strict semantic nullability, eventually we expect the executor to run validations that the field is not null and return an error if they are. While we wait for that capability to become available in `graphql-js` we implement our own runtime check in Grats.