### PR TITLE
Initial version of a ts-plugin

### DIFF
--- a/grats-ts-plugin/README.md
+++ b/grats-ts-plugin/README.md
@@ -1,0 +1,3 @@
+# grats-ts-plugin
+
+Experimental TypeScript plugin for Grats. This plugin is not ready for production use.

--- a/grats-ts-plugin/index.js
+++ b/grats-ts-plugin/index.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// TypeScript is vary particular about how plugins are structured. They must be
+// CommonJS and they must have a single value for `module.exports`. Additionally,
+// the plugin must be a plain module name (no `/` characters allowed).
+//
+// However, the logic for the plugin is tightly coupled with Grats itself and
+// should really live (and ship) alongside each version of Grats. While
+// I continue to struggle with figuring out how to let Grats operate as its own
+// TypeScript plugin, this package is just a shim.
+module.exports = require("grats").initTsPlugin;

--- a/grats-ts-plugin/package.json
+++ b/grats-ts-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "grats-ts-plugin",
+  "version": "0.0.2",
+  "license": "MIT",
+  "main": "./",
+  "module": "./index.js",
+  "peerDependencies": {
+    "grats": ">=0.0.19"
+  },
+  "prettier": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  grats-ts-plugin:
+    dependencies:
+      grats:
+        specifier: '>=0.0.19'
+        version: link:..
+
   website:
     dependencies:
       '@algolia/client-search':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'website'
   - 'examples/*'
+  - 'grats-ts-plugin'

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -31,6 +31,7 @@ import { applyDefaultNullability } from "./transforms/applyDefaultNullability";
 import { mergeExtensions } from "./transforms/mergeExtensions";
 import { sortSchemaAst } from "./transforms/sortSchemaAst";
 import { validateSemanticNullability } from "./validations/validateSemanticNullability";
+export { initTsPlugin } from "./tsPlugin/initTsPlugin";
 
 export type SchemaAndDoc = {
   schema: GraphQLSchema;

--- a/src/tsPlugin/initTsPlugin.ts
+++ b/src/tsPlugin/initTsPlugin.ts
@@ -1,0 +1,43 @@
+import type * as TS from "typescript/lib/tsserverlibrary";
+import { extract } from "../Extractor";
+
+// An experimental plugin for TypeScript that adds a new language service
+// which reports diagnostics for the current file. Currently it only reports
+// syntax errors because semantic errors are too expensive to compute on each
+// keystroke.
+export function initTsPlugin(modules: { typescript: typeof TS }) {
+  const ts = modules.typescript;
+
+  function create(info: TS.server.PluginCreateInfo): TS.LanguageService {
+    const projectRoot = info.project.getCurrentDirectory();
+    info.project.projectService.logger.info(
+      `Grats: Initializing Plugin with project root: ${projectRoot} and TypeScript version: ${ts.version}`,
+    );
+
+    // Set up decorator object
+    const proxy: TS.LanguageService = Object.create(null);
+    for (const k of Object.keys(info.languageService) as Array<
+      keyof TS.LanguageService
+    >) {
+      const x = info.languageService[k];
+      // @ts-expect-error
+      proxy[k] = (...args: Array<any>) => x.apply(info.languageService, args);
+    }
+
+    proxy.getSyntacticDiagnostics = (filename): TS.DiagnosticWithLocation[] => {
+      const prior = info.languageService.getSyntacticDiagnostics(filename);
+      const doc = info.languageService.getProgram()?.getSourceFile(filename);
+
+      if (doc == null) return prior;
+      const result = extract(doc);
+
+      if (result.kind === "OK") return prior;
+
+      return [...prior, ...result.err];
+    };
+
+    return proxy;
+  }
+
+  return { create };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "src/tests/fixtures",
     "docs",
     "examples",
-    "website"
+    "website",
+    "grats-ts-plugin"
   ]
 }


### PR DESCRIPTION
TypeScript lets you specify a plugin in your typescript config which can add additional functionality in the editor. This is a good fit for Grats which is built around the TypeScript compiler and could report helpful errors.

I'm still working to figure out a way to efficiently (re)compute cross-file validations, but this should give us a start by reporting syntax-only issues.

Ideally we could specify `grats` as the plugin itself, but from what I can tell TypeScript's requirements around the way the plugin is invoked are going to be hard to get to work inside the `grats` module itself:

1. The module has to use common js exports
2. The init function has the be the sole export from the module
3. The plugin module name must not have a slash in it

We could still explore having grats expose both a commonjs and ES Module version and have the commonjs version export the initi funciton with all the actual exports as properties on the function, but that's getting pretty crazy.

Since the logic of the plugin will be tightly coupled with Grats, I'm having the plugin extension just re-export the actual implementation from the grats module.

## Example

https://github.com/captbaritone/grats/assets/162735/4d57481e-e559-472e-b5a6-5799a609cb89

## Setup

Add the plugin to your tsconfig

```json5
{
  "grats": {
    "nullableByDefault": false
  },
  "compilerOptions": {
    // LIKE THIS
    "plugins": [{ "name": "grats-ts-plugin" }],
    "outDir": "dist",
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "target": "esnext",
    "lib": ["esnext"],
    "strict": true
  }
}
```

Configure VSCode to use your local version of TypeScript. Via `CMD+P` "TypeScript: Select TypeScript Version..." with a .ts file open or a `.vscode/settings.json` for your project with:

```json
{
    "typescript.tsdk": "node_modules/typescript/lib"
}
```


