### PR TITLE
Implement @oneOf input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes in this section are not yet released. If you need access to these change
 
 - **Features**
   - If a `@gqlType` which is used in an abstract type is defined using an exported `class`, an explicit `__typename` property is no-longer required. Grats can now generate code to infer the `__typename` based on the class definition. (#144)
+  - Support for `@oneOf` on input types. This allows you to define a discriminated union of input types. (#146)
 - **Bug Fixes**
   - The experimental TypeScript plugin will now report a diagnostics if it encounters a TypeScript version mismatch. (#143)
 

--- a/examples/production-app/README.md
+++ b/examples/production-app/README.md
@@ -10,6 +10,7 @@ This example includes a relatively fully featured app to demonstrate how real-wo
 - Subscriptions - See `Subscription.postLikes` in `models/LikeConnection.ts`
 - `@stream` - For expensive lists like `Viewer.feed` in `models/Viewer.ts`
 - Custom scalars - See `Date` defined in `graphql/CustomScalars.ts`
+- OneOf input types for modeling Markdown content in `models/Post.ts`
 
 ## Implementation notes
 

--- a/examples/production-app/package.json
+++ b/examples/production-app/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@graphql-yoga/plugin-defer-stream": "^3.1.1",
     "dataloader": "^2.2.2",
-    "graphql": "16.8.1",
+    "graphql": "16.9.0",
     "graphql-relay": "^0.10.0",
     "graphql-yoga": "^5.0.0",
     "typescript": "^5.5.4"

--- a/examples/production-app/schema.graphql
+++ b/examples/production-app/schema.graphql
@@ -25,12 +25,29 @@ input CreateLikeInput {
 
 input CreatePostInput {
   authorId: ID!
-  content: String!
+  content: PostContentInput!
   title: String!
 }
 
 input CreateUserInput {
   name: String!
+}
+
+"""Models a node in a Markdown AST"""
+input MarkdownNode @oneOf {
+  blockquote: String
+  h1: String
+  h2: String
+  h3: String
+  li: [String!]
+  p: String
+  ul: [String!]
+}
+
+"""Post content. Could be pure text, or Markdown"""
+input PostContentInput @oneOf {
+  markdown: [MarkdownNode!]
+  string: String
 }
 
 type CreateLikePayload {

--- a/examples/production-app/schema.ts
+++ b/examples/production-app/schema.ts
@@ -475,6 +475,60 @@ export function getSchema(): GraphQLSchema {
             };
         }
     });
+    const MarkdownNodeType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        description: "Models a node in a Markdown AST",
+        name: "MarkdownNode",
+        fields() {
+            return {
+                blockquote: {
+                    name: "blockquote",
+                    type: GraphQLString
+                },
+                h1: {
+                    name: "h1",
+                    type: GraphQLString
+                },
+                h2: {
+                    name: "h2",
+                    type: GraphQLString
+                },
+                h3: {
+                    name: "h3",
+                    type: GraphQLString
+                },
+                li: {
+                    name: "li",
+                    type: new GraphQLList(new GraphQLNonNull(GraphQLString))
+                },
+                p: {
+                    name: "p",
+                    type: GraphQLString
+                },
+                ul: {
+                    name: "ul",
+                    type: new GraphQLList(new GraphQLNonNull(GraphQLString))
+                }
+            };
+        },
+        isOneOf: true
+    });
+    const PostContentInputType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        description: "Post content. Could be pure text, or Markdown",
+        name: "PostContentInput",
+        fields() {
+            return {
+                markdown: {
+                    name: "markdown",
+                    type: new GraphQLList(new GraphQLNonNull(MarkdownNodeType))
+                },
+                string: {
+                    name: "string",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
     const CreatePostInputType: GraphQLInputObjectType = new GraphQLInputObjectType({
         name: "CreatePostInput",
         fields() {
@@ -485,7 +539,7 @@ export function getSchema(): GraphQLSchema {
                 },
                 content: {
                     name: "content",
-                    type: new GraphQLNonNull(GraphQLString)
+                    type: new GraphQLNonNull(PostContentInputType)
                 },
                 title: {
                     name: "title",
@@ -593,6 +647,6 @@ export function getSchema(): GraphQLSchema {
         query: QueryType,
         mutation: MutationType,
         subscription: SubscriptionType,
-        types: [DateType, NodeType, CreateLikeInputType, CreatePostInputType, CreateUserInputType, CreateLikePayloadType, CreatePostPayloadType, CreateUserPayloadType, LikeType, LikeConnectionType, LikeEdgeType, MutationType, PageInfoType, PostType, PostConnectionType, PostEdgeType, QueryType, SubscriptionType, UserType, UserConnectionType, UserEdgeType, ViewerType]
+        types: [DateType, NodeType, CreateLikeInputType, CreatePostInputType, CreateUserInputType, MarkdownNodeType, PostContentInputType, CreateLikePayloadType, CreatePostPayloadType, CreateUserPayloadType, LikeType, LikeConnectionType, LikeEdgeType, MutationType, PageInfoType, PostType, PostConnectionType, PostEdgeType, QueryType, SubscriptionType, UserType, UserConnectionType, UserEdgeType, ViewerType]
     });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,19 +190,19 @@ importers:
     dependencies:
       '@graphql-yoga/plugin-defer-stream':
         specifier: ^3.1.1
-        version: 3.1.1(graphql-yoga@5.0.0(graphql@16.8.1))(graphql@16.8.1)
+        version: 3.1.1(graphql-yoga@5.0.0(graphql@16.9.0))(graphql@16.9.0)
       dataloader:
         specifier: ^2.2.2
         version: 2.2.2
       graphql:
-        specifier: 16.8.1
-        version: 16.8.1
+        specifier: 16.9.0
+        version: 16.9.0
       graphql-relay:
         specifier: ^0.10.0
-        version: 0.10.0(graphql@16.8.1)
+        version: 0.10.0(graphql@16.9.0)
       graphql-yoga:
         specifier: ^5.0.0
-        version: 5.0.0(graphql@16.8.1)
+        version: 5.0.0(graphql@16.9.0)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -10620,7 +10620,7 @@ snapshots:
       terser-webpack-plugin: 5.3.10(webpack@5.90.3)
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3))(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.78.0))(webpack@5.90.3)
       webpack: 5.90.3
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.2(webpack@5.90.3)
@@ -10682,7 +10682,7 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3))(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.78.0))(webpack@5.90.3)
       vfile: 6.0.2
       webpack: 5.90.3
     transitivePeerDependencies:
@@ -11228,7 +11228,7 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3))(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.78.0))(webpack@5.90.3)
       utility-types: 3.10.0
       webpack: 5.90.3
     optionalDependencies:
@@ -11450,6 +11450,15 @@ snapshots:
       tslib: 2.6.2
       value-or-promise: 1.0.12
 
+  '@graphql-tools/executor@1.2.0(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@repeaterjs/repeater': 3.0.5
+      graphql: 16.9.0
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+
   '@graphql-tools/merge@8.4.2(graphql@16.8.1)':
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
@@ -11462,11 +11471,25 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.2
 
+  '@graphql-tools/merge@9.0.4(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.2.0(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.2
+
   '@graphql-tools/schema@10.0.3(graphql@16.8.1)':
     dependencies:
       '@graphql-tools/merge': 9.0.4(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+
+  '@graphql-tools/schema@10.0.3(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/merge': 9.0.4(graphql@16.9.0)
+      '@graphql-tools/utils': 10.2.0(graphql@16.9.0)
+      graphql: 16.9.0
       tslib: 2.6.2
       value-or-promise: 1.0.12
 
@@ -11478,12 +11501,12 @@ snapshots:
       tslib: 2.6.2
       value-or-promise: 1.0.12
 
-  '@graphql-tools/utils@10.0.8(graphql@16.8.1)':
+  '@graphql-tools/utils@10.0.8(graphql@16.9.0)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       cross-inspect: 1.0.0
       dset: 3.1.3
-      graphql: 16.8.1
+      graphql: 16.9.0
       tslib: 2.6.2
 
   '@graphql-tools/utils@10.2.0(graphql@16.8.1)':
@@ -11492,6 +11515,14 @@ snapshots:
       cross-inspect: 1.0.0
       dset: 3.1.3
       graphql: 16.8.1
+      tslib: 2.6.2
+
+  '@graphql-tools/utils@10.2.0(graphql@16.9.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      cross-inspect: 1.0.0
+      dset: 3.1.3
+      graphql: 16.9.0
       tslib: 2.6.2
 
   '@graphql-tools/utils@9.2.1(graphql@16.6.0)':
@@ -11528,15 +11559,19 @@ snapshots:
     dependencies:
       graphql: 16.8.1
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
+
   '@graphql-yoga/logger@2.0.0':
     dependencies:
       tslib: 2.6.2
 
-  '@graphql-yoga/plugin-defer-stream@3.1.1(graphql-yoga@5.0.0(graphql@16.8.1))(graphql@16.8.1)':
+  '@graphql-yoga/plugin-defer-stream@3.1.1(graphql-yoga@5.0.0(graphql@16.9.0))(graphql@16.9.0)':
     dependencies:
-      '@graphql-tools/utils': 10.0.8(graphql@16.8.1)
-      graphql: 16.8.1
-      graphql-yoga: 5.0.0(graphql@16.8.1)
+      '@graphql-tools/utils': 10.0.8(graphql@16.9.0)
+      graphql: 16.9.0
+      graphql-yoga: 5.0.0(graphql@16.9.0)
 
   '@graphql-yoga/subscription@5.0.0':
     dependencies:
@@ -15846,9 +15881,9 @@ snapshots:
     dependencies:
       graphql: 16.6.0
 
-  graphql-relay@0.10.0(graphql@16.8.1):
+  graphql-relay@0.10.0(graphql@16.9.0):
     dependencies:
-      graphql: 16.8.1
+      graphql: 16.9.0
 
   graphql-yoga@5.0.0(graphql@16.8.1):
     dependencies:
@@ -15862,6 +15897,21 @@ snapshots:
       '@whatwg-node/server': 0.9.16
       dset: 3.1.3
       graphql: 16.8.1
+      lru-cache: 10.0.2
+      tslib: 2.6.2
+
+  graphql-yoga@5.0.0(graphql@16.9.0):
+    dependencies:
+      '@envelop/core': 5.0.0
+      '@graphql-tools/executor': 1.2.0(graphql@16.9.0)
+      '@graphql-tools/schema': 10.0.3(graphql@16.9.0)
+      '@graphql-tools/utils': 10.2.0(graphql@16.9.0)
+      '@graphql-yoga/logger': 2.0.0
+      '@graphql-yoga/subscription': 5.0.0
+      '@whatwg-node/fetch': 0.9.14
+      '@whatwg-node/server': 0.9.16
+      dset: 3.1.3
+      graphql: 16.9.0
       lru-cache: 10.0.2
       tslib: 2.6.2
 
@@ -20267,7 +20317,7 @@ snapshots:
 
   urix@0.1.0: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.90.3))(webpack@5.90.3):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.78.0))(webpack@5.90.3):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -519,12 +519,8 @@ export function oneOfNotSupportedGraphql(
   return `OneOf input types are only supported in \`graphql@${requiredVersion}\` and later but Grats found \`graphql@${foundVersion}\`. Please upgrade your version of graphql-js in order to use this feature.`;
 }
 
-export function oneOfNotOnTypeAlias(): string {
-  return "Expected @oneOf @gqlInput to be on a type alias.";
-}
-
 export function oneOfNotOnUnion(): string {
-  return "Expected the type of a @oneOf @gqlInput to be a TypeScript union.";
+  return "Expected the type of a @gqlInput with @oneOf to be attached to a TypeScript union.";
 }
 
 export function oneOfFieldNotTypeLiteralWithOneProperty(): string {

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -511,3 +511,26 @@ export function staticMethodOnNonClass(): string {
 export function staticMethodClassWithNamedExportNotNamed(): string {
   return `Expected \`@${FIELD_TAG}\` static method's class to be named if exported without the \`default\` keyword.`;
 }
+
+export function oneOfNotSupportedGraphql(
+  requiredVersion: string,
+  foundVersion: string,
+): string {
+  return `OneOf input types are only supported in \`graphql@${requiredVersion}\` and later but Grats found \`graphql@${foundVersion}\`. Please upgrade your version of graphql-js in order to use this feature.`;
+}
+
+export function oneOfNotOnTypeAlias(): string {
+  return "Expected @oneOf @gqlInput to be on a type alias.";
+}
+
+export function oneOfNotOnUnion(): string {
+  return "Expected the type of a @oneOf @gqlInput to be a TypeScript union.";
+}
+
+export function oneOfFieldNotTypeLiteralWithOneProperty(): string {
+  return "Expected each member of a @oneOf @gqlInput to be a TypeScript object literal with exactly one property.";
+}
+
+export function oneOfPropertyMissingTypeAnnotation(): string {
+  return "Expected each property of a @oneOf @gqlInput to have a type annotation.";
+}

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -679,7 +679,7 @@ class Extractor {
       );
     }
     if (!ts.isTypeAliasDeclaration(node)) {
-      return this.report(node, E.oneOfNotOnTypeAlias());
+      return this.report(node, E.oneOfNotOnUnion());
     }
     const name = this.entityName(node, tag);
     if (name == null) return null;

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -681,7 +681,6 @@ class Extractor {
     if (!ts.isTypeAliasDeclaration(node)) {
       return this.report(node, E.oneOfNotOnTypeAlias());
     }
-    // FIXME: Check graphql-js version
     const name = this.entityName(node, tag);
     if (name == null) return null;
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -556,11 +556,15 @@ class Codegen {
   }
 
   inputTypeConfig(obj: GraphQLInputObjectType): ts.ObjectLiteralExpression {
-    return this.objectLiteral([
+    const properties = [
       this.description(obj.description),
       F.createPropertyAssignment("name", F.createStringLiteral(obj.name)),
       this.inputFields(obj),
-    ]);
+    ];
+    if (obj.isOneOf) {
+      properties.push(F.createPropertyAssignment("isOneOf", F.createTrue()));
+    }
+    return this.objectLiteral(properties);
   }
 
   inputFields(obj: GraphQLInputObjectType): ts.MethodDeclaration {

--- a/src/tests/fixtures/input_type_one_of/oneOfDeprecated.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfDeprecated.invalid.ts
@@ -1,0 +1,6 @@
+/**
+ * @gqlInput
+ * @oneOf
+ * @deprecated Don't use this any more
+ */
+export type Greeting = { firstName: string } | { lastName: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfDeprecated.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfDeprecated.invalid.ts.expected
@@ -1,0 +1,17 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ * @deprecated Don't use this any more
+ */
+export type Greeting = { firstName: string } | { lastName: string };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfDeprecated.invalid.ts:4:5 - error: Directive "@deprecated" may not be used on INPUT_OBJECT.
+
+4  * @deprecated Don't use this any more
+      ~~~~~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldIsNullable.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldIsNullable.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string | null };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldIsNullable.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldIsNullable.ts.expected
@@ -1,0 +1,40 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string | null };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldIsOptional.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldIsOptional.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName?: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldIsOptional.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldIsOptional.ts.expected
@@ -1,0 +1,40 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName?: string };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldMissingTypeAnnotation.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldMissingTypeAnnotation.invalid.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldMissingTypeAnnotation.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldMissingTypeAnnotation.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfFieldMissingTypeAnnotation.invalid.ts:5:50 - error: Expected each property of a @oneOf @gqlInput to have a type annotation.
+
+5 export type Greeting = { firstName: string } | { lastName };
+                                                   ~~~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeList.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeList.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: Array<string> };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeList.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeList.ts.expected
@@ -1,0 +1,40 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: Array<string> };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: [String!]
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString, GraphQLList, GraphQLNonNull } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: new GraphQLList(new GraphQLNonNull(GraphQLString))
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeListOfNullable.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeListOfNullable.ts
@@ -1,0 +1,7 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | { firstName: string }
+  | { lastName: Array<string | null> };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeListOfNullable.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeListOfNullable.ts.expected
@@ -1,0 +1,42 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | { firstName: string }
+  | { lastName: Array<string | null> };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: [String]
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString, GraphQLList } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: new GraphQLList(GraphQLString)
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeNotGraphQL.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeNotGraphQL.invalid.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: Set<string> };

--- a/src/tests/fixtures/input_type_one_of/oneOfFieldTypeNotGraphQL.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfFieldTypeNotGraphQL.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: Set<string> };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfFieldTypeNotGraphQL.invalid.ts:5:60 - error: Unable to resolve type reference. In order to generate a GraphQL schema, Grats needs to determine which GraphQL type is being referenced. This requires being able to resolve type references to their `@gql` annotated declaration. However this reference could not be resolved. Is it possible that this type is not defined in this file?
+
+5 export type Greeting = { firstName: string } | { lastName: Set<string> };
+                                                             ~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfMemberHasMultipleFields.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfMemberHasMultipleFields.invalid.ts
@@ -1,0 +1,7 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | { firstName: string }
+  | { lastName: string; nickName: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfMemberHasMultipleFields.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfMemberHasMultipleFields.invalid.ts.expected
@@ -1,0 +1,18 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | { firstName: string }
+  | { lastName: string; nickName: string };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfMemberHasMultipleFields.invalid.ts:7:5 - error: Expected each member of a @oneOf @gqlInput to be a TypeScript object literal with exactly one property.
+
+7   | { lastName: string; nickName: string };
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfMemberHasNoField.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfMemberHasNoField.invalid.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+type Greeting = { firstName: string } | {};

--- a/src/tests/fixtures/input_type_one_of/oneOfMemberHasNoField.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfMemberHasNoField.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+type Greeting = { firstName: string } | {};
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfMemberHasNoField.invalid.ts:5:41 - error: Expected each member of a @oneOf @gqlInput to be a TypeScript object literal with exactly one property.
+
+5 type Greeting = { firstName: string } | {};
+                                          ~~

--- a/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export class Greeting {}

--- a/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts.expected
@@ -10,7 +10,7 @@ export class Greeting {}
 -----------------
 OUTPUT
 -----------------
-src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts:5:1 - error: Expected @oneOf @gqlInput to be on a type alias.
+src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts:5:1 - error: Expected the type of a @gqlInput with @oneOf to be attached to a TypeScript union.
 
 5 export class Greeting {}
   ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export class Greeting {}
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfNotOnType.invalid.ts:5:1 - error: Expected @oneOf @gqlInput to be on a type alias.
+
+5 export class Greeting {}
+  ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfOnlyOneField.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfOnlyOneField.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfOnlyOneField.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfOnlyOneField.ts.expected
@@ -1,0 +1,35 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfUnionMemberNotLiteral.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfUnionMemberNotLiteral.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = string | { name: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfUnionMemberNotLiteral.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfUnionMemberNotLiteral.ts.expected
@@ -1,0 +1,16 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = string | { name: string };
+
+-----------------
+OUTPUT
+-----------------
+src/tests/fixtures/input_type_one_of/oneOfUnionMemberNotLiteral.ts:5:24 - error: Expected each member of a @oneOf @gqlInput to be a TypeScript object literal with exactly one property.
+
+5 export type Greeting = string | { name: string };
+                         ~~~~~~

--- a/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescription.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescription.ts
@@ -1,0 +1,11 @@
+// Known issue, descriptions are not parsed?
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  /** First Name */
+  | { firstName: string }
+  /** Last Name */
+  | { lastName: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescription.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescription.ts.expected
@@ -1,0 +1,46 @@
+-----------------
+INPUT
+----------------- 
+// Known issue, descriptions are not parsed?
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  /** First Name */
+  | { firstName: string }
+  /** Last Name */
+  | { lastName: string };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescriptionInsideObj.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescriptionInsideObj.ts
@@ -1,0 +1,15 @@
+// Known issue, descriptions are not parsed?
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | {
+      /** First Name */
+      firstName: string;
+    }
+  | {
+      /** Last Name */
+      lastName: string;
+    };

--- a/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescriptionInsideObj.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithFieldDescriptionInsideObj.ts.expected
@@ -1,0 +1,54 @@
+-----------------
+INPUT
+----------------- 
+// Known issue, descriptions are not parsed?
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting =
+  | {
+      /** First Name */
+      firstName: string;
+    }
+  | {
+      /** Last Name */
+      lastName: string;
+    };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  """First Name"""
+  firstName: String
+  """Last Name"""
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    description: "First Name",
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    description: "Last Name",
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/oneOfWithTypeDescription.ts
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithTypeDescription.ts
@@ -1,0 +1,7 @@
+/**
+ * A popular way to greet someone.
+ *
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string };

--- a/src/tests/fixtures/input_type_one_of/oneOfWithTypeDescription.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/oneOfWithTypeDescription.ts.expected
@@ -1,0 +1,44 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * A popular way to greet someone.
+ *
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+"""A popular way to greet someone."""
+input Greeting @oneOf {
+  firstName: String
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        description: "A popular way to greet someone.",
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/fixtures/input_type_one_of/simpleOneOf.ts
+++ b/src/tests/fixtures/input_type_one_of/simpleOneOf.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string };

--- a/src/tests/fixtures/input_type_one_of/simpleOneOf.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/simpleOneOf.ts.expected
@@ -1,0 +1,40 @@
+-----------------
+INPUT
+----------------- 
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type Greeting = { firstName: string } | { lastName: string };
+
+-----------------
+OUTPUT
+-----------------
+-- SDL --
+input Greeting @oneOf {
+  firstName: String
+  lastName: String
+}
+-- TypeScript --
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                firstName: {
+                    name: "firstName",
+                    type: GraphQLString
+                },
+                lastName: {
+                    name: "lastName",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [GreetingType]
+    });
+}

--- a/src/tests/integrationFixtures/inputTypeOneOf/index.ts
+++ b/src/tests/integrationFixtures/inputTypeOneOf/index.ts
@@ -1,0 +1,39 @@
+import { ID } from "../../..";
+
+/** @gqlInput */
+type UserPayload = {
+  id: ID;
+  name: string;
+};
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+type Greeting = { name: string } | { userId: ID } | { user: UserPayload };
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField */
+export function greet(_: Query, args: { greeting: Greeting }): string {
+  const greeting = args.greeting;
+  switch (true) {
+    case "name" in greeting:
+      return `Hello, ${greeting.name}!`;
+    case "userId" in greeting:
+      return `Hello, user with ID ${greeting.userId}!`;
+    case "user" in greeting:
+      return `Hello, ${greeting.user.name} with ID ${greeting.user.id}!`;
+    default:
+      // Assert exhaustive
+      const _exhaustiveCheck: never = greeting;
+      throw new Error(`Unexpected greeting: ${JSON.stringify(args.greeting)}`);
+  }
+}
+
+export const query = `
+    query {
+      greet(greeting: { name: "Alice" })
+    }
+  `;

--- a/src/tests/integrationFixtures/inputTypeOneOf/index.ts.expected
+++ b/src/tests/integrationFixtures/inputTypeOneOf/index.ts.expected
@@ -1,0 +1,51 @@
+-----------------
+INPUT
+----------------- 
+import { ID } from "../../..";
+
+/** @gqlInput */
+type UserPayload = {
+  id: ID;
+  name: string;
+};
+
+/**
+ * @gqlInput
+ * @oneOf
+ */
+type Greeting = { name: string } | { userId: ID } | { user: UserPayload };
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlField */
+export function greet(_: Query, args: { greeting: Greeting }): string {
+  const greeting = args.greeting;
+  switch (true) {
+    case "name" in greeting:
+      return `Hello, ${greeting.name}!`;
+    case "userId" in greeting:
+      return `Hello, user with ID ${greeting.userId}!`;
+    case "user" in greeting:
+      return `Hello, ${greeting.user.name} with ID ${greeting.user.id}!`;
+    default:
+      // Assert exhaustive
+      const _exhaustiveCheck: never = greeting;
+      throw new Error(`Unexpected greeting: ${JSON.stringify(args.greeting)}`);
+  }
+}
+
+export const query = `
+    query {
+      greet(greeting: { name: "Alice" })
+    }
+  `;
+
+-----------------
+OUTPUT
+-----------------
+{
+  "data": {
+    "greet": "Hello, Alice!"
+  }
+}

--- a/src/tests/integrationFixtures/inputTypeOneOf/schema.ts
+++ b/src/tests/integrationFixtures/inputTypeOneOf/schema.ts
@@ -1,0 +1,63 @@
+import { greet as queryGreetResolver } from "./index";
+import { GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLInputObjectType, GraphQLID } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const UserPayloadType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "UserPayload",
+        fields() {
+            return {
+                id: {
+                    name: "id",
+                    type: new GraphQLNonNull(GraphQLID)
+                },
+                name: {
+                    name: "name",
+                    type: new GraphQLNonNull(GraphQLString)
+                }
+            };
+        }
+    });
+    const GreetingType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "Greeting",
+        fields() {
+            return {
+                name: {
+                    name: "name",
+                    type: GraphQLString
+                },
+                user: {
+                    name: "user",
+                    type: UserPayloadType
+                },
+                userId: {
+                    name: "userId",
+                    type: GraphQLID
+                }
+            };
+        },
+        isOneOf: true
+    });
+    const QueryType: GraphQLObjectType = new GraphQLObjectType({
+        name: "Query",
+        fields() {
+            return {
+                greet: {
+                    name: "greet",
+                    type: GraphQLString,
+                    args: {
+                        greeting: {
+                            name: "greeting",
+                            type: new GraphQLNonNull(GreetingType)
+                        }
+                    },
+                    resolve(source, args) {
+                        return queryGreetResolver(source, args);
+                    }
+                }
+            };
+        }
+    });
+    return new GraphQLSchema({
+        query: QueryType,
+        types: [GreetingType, UserPayloadType, QueryType]
+    });
+}

--- a/website/docs/04-docblock-tags/10-oneof-inputs.mdx
+++ b/website/docs/04-docblock-tags/10-oneof-inputs.mdx
@@ -1,0 +1,38 @@
+import GratsCode from "@site/src/components/GratsCode";
+import OneOf from "!!raw-loader!./snippets/10-one-of-input.out";
+import OneOfDescription from "!!raw-loader!./snippets/10-one-of-input-descriptions.out";
+import OneOfExhaustive from "!!raw-loader!./snippets/10-one-of-input-exhaustive.out";
+
+# OneOf Input
+
+OneOf input types are an experimental GraphQL feature, currently a [draft stage RFC](https://github.com/graphql/graphql-spec/pull/825), which lets you define an input type where exactly one of the fields must be provided. This can be useful for modeling structures similar to [unions](./06-unions.mdx) but for input types.
+
+OneOf inputs can be defined by placing both `@gqlInput` and `@oneOf` in a docblock directly before a:
+
+- Type alias of a union of object literal types
+
+The union must be a union of object types, and each object type must have exactly one property whose value is a valid [input type](./09-inputs.mdx). You can think of each member of the union as modeling one of the possible values the user might provide as a valid input.
+
+:::info
+OneOf is not supported in versions of graphql-js earlier than `v16.9.0`. If you are using an older version of graphql-js, you will need to upgrade to use this feature.
+:::
+
+<GratsCode out={OneOf} mode="both" />
+
+## OneOf input field descriptions
+
+TypeScript does not support docblocks "attach" to a member of a union. Therefore, if you want to provide a description for a field of a OneOf input, place it above the field, within the object literal:
+
+<GratsCode out={OneOfDescription} mode="both" />
+
+## Working with OneOf inputs
+
+When handling one of these types in TypeScript it is a best practice to use an exhaustive switch. This way, if you add a new option to the union, TypeScript will trigger an error in all the locations where you handle the union.
+
+_As of TypeScript 5.3.0_, TypeScript supports a pattern called [Switch True Narrowing](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html#switch-true-narrowing) which can be used to ensure that you have handled all the possible options in this type of union. It looks like this:
+
+<GratsCode out={OneOfExhaustive} mode="both" />
+
+:::note
+Grats is open to supporting other syntaxes for defining OneOf inputs. If you have a syntax that you find more intuitive, please [open an issue](https://github.com/captbaritone/grats/issues/new).
+:::

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input-descriptions.grats.ts
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input-descriptions.grats.ts
@@ -1,0 +1,13 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy =
+  | {
+      /** Fetch the user by email */
+      email: string;
+    }
+  | {
+      /** Fetch the user by username */
+      username: string;
+    };

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input-descriptions.out
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input-descriptions.out
@@ -1,0 +1,46 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy =
+  | {
+      /** Fetch the user by email */
+      email: string;
+    }
+  | {
+      /** Fetch the user by username */
+      username: string;
+    };
+
+=== SNIP ===
+input UserBy @oneOf {
+  """Fetch the user by email"""
+  email: String
+  """Fetch the user by username"""
+  username: String
+}
+=== SNIP ===
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const UserByType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "UserBy",
+        fields() {
+            return {
+                email: {
+                    description: "Fetch the user by email",
+                    name: "email",
+                    type: GraphQLString
+                },
+                username: {
+                    description: "Fetch the user by username",
+                    name: "username",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [UserByType]
+    });
+}

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input-exhaustive.grats.ts
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input-exhaustive.grats.ts
@@ -1,0 +1,45 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy = { email: string } | { username: string };
+
+/** @gqlField */
+export function getUser(_: Query, args: { by: UserBy }): User {
+  // highlight-start
+  switch (true) {
+    case "email" in args.by:
+      return User.fromEmail(args.by.email);
+    case "username" in args.by:
+      return User.fromUsername(args.by.username);
+    default: {
+      // This line will error if an unhandled option is added to the union
+      const _exhaustive: never = args.by;
+      throw new Error(`Unhandled case: ${JSON.stringify(args.by)}`);
+    }
+  }
+  // highlight-end
+}
+// trim-start
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlType */
+class User {
+  constructor(
+    /** @gqlField */
+    public email?: string,
+    /** @gqlField */
+    public username?: string,
+  ) {}
+
+  static fromEmail(email: string): User {
+    return new User(email, undefined);
+  }
+
+  static fromUsername(username: string): User {
+    return new User(undefined, username);
+  }
+}
+// trim-end

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input-exhaustive.out
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input-exhaustive.out
@@ -1,0 +1,120 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy = { email: string } | { username: string };
+
+/** @gqlField */
+export function getUser(_: Query, args: { by: UserBy }): User {
+  // highlight-start
+  switch (true) {
+    case "email" in args.by:
+      return User.fromEmail(args.by.email);
+    case "username" in args.by:
+      return User.fromUsername(args.by.username);
+    default: {
+      // This line will error if an unhandled option is added to the union
+      const _exhaustive: never = args.by;
+      throw new Error(`Unhandled case: ${JSON.stringify(args.by)}`);
+    }
+  }
+  // highlight-end
+}
+// trim-start
+
+/** @gqlType */
+type Query = unknown;
+
+/** @gqlType */
+class User {
+  constructor(
+    /** @gqlField */
+    public email?: string,
+    /** @gqlField */
+    public username?: string,
+  ) {}
+
+  static fromEmail(email: string): User {
+    return new User(email, undefined);
+  }
+
+  static fromUsername(username: string): User {
+    return new User(undefined, username);
+  }
+}
+// trim-end
+
+=== SNIP ===
+input UserBy @oneOf {
+  email: String
+  username: String
+}
+
+type Query {
+  getUser(by: UserBy!): User
+}
+
+type User {
+  email: String
+  username: String
+}
+=== SNIP ===
+import { getUser as queryGetUserResolver } from "./10-one-of-input-exhaustive.grats";
+import { GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLInputObjectType } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const UserType: GraphQLObjectType = new GraphQLObjectType({
+        name: "User",
+        fields() {
+            return {
+                email: {
+                    name: "email",
+                    type: GraphQLString
+                },
+                username: {
+                    name: "username",
+                    type: GraphQLString
+                }
+            };
+        }
+    });
+    const UserByType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "UserBy",
+        fields() {
+            return {
+                email: {
+                    name: "email",
+                    type: GraphQLString
+                },
+                username: {
+                    name: "username",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    const QueryType: GraphQLObjectType = new GraphQLObjectType({
+        name: "Query",
+        fields() {
+            return {
+                getUser: {
+                    name: "getUser",
+                    type: UserType,
+                    args: {
+                        by: {
+                            name: "by",
+                            type: new GraphQLNonNull(UserByType)
+                        }
+                    },
+                    resolve(source, args) {
+                        return queryGetUserResolver(source, args);
+                    }
+                }
+            };
+        }
+    });
+    return new GraphQLSchema({
+        query: QueryType,
+        types: [UserByType, QueryType, UserType]
+    });
+}

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input.grats.ts
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input.grats.ts
@@ -1,0 +1,5 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy = { email: string } | { username: string };

--- a/website/docs/04-docblock-tags/snippets/10-one-of-input.out
+++ b/website/docs/04-docblock-tags/snippets/10-one-of-input.out
@@ -1,0 +1,34 @@
+/**
+ * @gqlInput
+ * @oneOf
+ */
+export type UserBy = { email: string } | { username: string };
+
+=== SNIP ===
+input UserBy @oneOf {
+  email: String
+  username: String
+}
+=== SNIP ===
+import { GraphQLSchema, GraphQLInputObjectType, GraphQLString } from "graphql";
+export function getSchema(): GraphQLSchema {
+    const UserByType: GraphQLInputObjectType = new GraphQLInputObjectType({
+        name: "UserBy",
+        fields() {
+            return {
+                email: {
+                    name: "email",
+                    type: GraphQLString
+                },
+                username: {
+                    name: "username",
+                    type: GraphQLString
+                }
+            };
+        },
+        isOneOf: true
+    });
+    return new GraphQLSchema({
+        types: [UserByType]
+    });
+}

--- a/website/docs/05-examples/10-production-app.md
+++ b/website/docs/05-examples/10-production-app.md
@@ -12,6 +12,7 @@ This example includes a relatively fully featured app to demonstrate how real-wo
 - Subscriptions - See `Subscription.postLikes` in `models/LikeConnection.ts`
 - `@stream` - For expensive lists like `Viewer.feed` in `models/Viewer.ts`
 - Custom scalars - See `Date` defined in `graphql/CustomScalars.ts`
+- [OneOf input types](../04-docblock-tags/10-oneof-inputs.mdx) for modeling Markdown content in `models/Post.ts`
 
 ## Implementation notes
 

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -27,3 +27,6 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
 from = "https://grats.netlify.app/*"
 to = "https://grats.capt.dev/:splat"
 status = 301
+
+[build.environment]
+NODE_VERSION = "20.10.0"

--- a/website/package.json
+++ b/website/package.json
@@ -77,5 +77,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "pnpm@9.3.0"
 }


### PR DESCRIPTION
Support for the `@oneOf` RFC using syntax like:

```ts
/**
 * Models a node in a Markdown AST
 * @gqlInput
 * @oneOf
 */
type MarkdownNode =
  | { h1: string }
  | { h2: string }
  | { h3: string }
  | { p: string }
  | { blockquote: string }
  | { ul: string[] }
  | { li: string[] };
  ```