### PR TITLE
Return undefined from graphql-js visit when not modifying node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .parcel-cache
 .vercel
 .claude
+performance.cpuprofile
 
 # Local Netlify folder
 .netlify

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "integration-tests": "node src/tests/integration.mjs",
     "build": "rm -rf dist/ && tsc --build",
     "format": "prettier . --write",
-    "lint": "eslint . && prettier . --check"
+    "lint": "eslint . && prettier . --check",
+    "profile": "ts-node scripts/profile.ts"
   },
   "dependencies": {
     "commander": "^10.0.0",

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { execSync } from "child_process";
+
+/** Create a large Grats project for performance testing */
+
+export async function main() {
+  // Create a temp directory to run the benchmark in.
+  const tmpDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "grats-benchmark-tests-"),
+  );
+
+  // Create a tsconfig.json file.
+  const tsConfigPath = path.join(tmpDir, "tsconfig.json");
+  const tsConfig = {
+    grats: {
+      // See Configuration for all available options
+    },
+    compilerOptions: {
+      strictNullChecks: true,
+      module: "NodeNext",
+      outDir: "./dist",
+    },
+  };
+  await fs.writeFile(tsConfigPath, JSON.stringify(tsConfig, null, 2));
+
+  // Create a large number of TypeScript files with GraphQL definitions.
+  const numFiles = 10000;
+  const template = (fileIndex: number): string => {
+    let prelude = "";
+    let edge = "";
+    let prevType = "";
+    if (fileIndex > 0) {
+      prevType = `Type${fileIndex - 1}`;
+      prelude = `import { ${prevType} } from "./file${fileIndex - 1}";\n`;
+      edge = `  /** @gqlField */
+  previous(): ${prevType} {
+    return new ${prevType}();
+  }`;
+    }
+    return `
+${prelude}
+
+/** @gqlType */
+export class Type${fileIndex} {
+  /** @gqlField */
+  field(): string {
+    return "Hello, world!";
+  }
+  
+  /** @gqlQueryField */
+  static getType${fileIndex}(): string {
+    return new Type${fileIndex}();
+  }
+
+  ${edge}
+}
+
+/** @gqlEnum */
+export enum Enum${fileIndex} {
+  VALUE_A = "VALUE_A",
+  VALUE_B = "VALUE_B",
+  VALUE_C = "VALUE_C",
+}
+
+/** @gqlInput */
+type Input${fileIndex} = {
+  field: string;
+  someEnum: Enum${fileIndex};
+}
+
+/** @gqlMutationField */
+export function createType${fileIndex}(input: Input${fileIndex}): Type${fileIndex} {
+  return new Type${fileIndex}();
+}
+
+/** @gqlQueryField */
+export function queryField${fileIndex}(): string {
+  return "Hello, world!";
+}`;
+  };
+
+  for (let i = 0; i < numFiles; i++) {
+    const fileContents = template(i);
+    const filePath = path.join(tmpDir, `file${i}.ts`);
+    await fs.writeFile(filePath, fileContents);
+  }
+
+  // Change directory to the temp directory.
+  // process.chdir(tmpDir);
+
+  // Run Grats in the temp directory and take a performance profile
+  console.log("Running Grats...");
+  console.time("Grats completed in");
+  execSync(
+    `node --cpu-prof --cpu-prof-name=performance.cpuprofile /Users/captbaritone/projects/grats/dist/src/cli.js --tsconfig ${tsConfigPath}`,
+    {
+      stdio: "inherit",
+    },
+  );
+  console.timeEnd("Grats completed in");
+
+  // Clean up the temp directory.
+  await fs.rm(tmpDir, { recursive: true, force: true });
+}
+
+main();

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -51,7 +51,7 @@ export function printSDLWithoutMetadata(doc: DocumentNode): string {
     ScalarTypeDefinition(t) {
       return specifiedScalarTypes.some((scalar) => scalar.name === t.name.value)
         ? null
-        : t;
+        : undefined;
     },
   });
   return print(trimmed);

--- a/src/transforms/applyDefaultNullability.ts
+++ b/src/transforms/applyDefaultNullability.ts
@@ -54,7 +54,7 @@ export function applyDefaultNullability(
         }
         return { ...t, directives, type };
       }
-      return t;
+      return undefined;
     },
   });
   if (errors.length > 0) {

--- a/src/transforms/coerceDefaultEnumValues.ts
+++ b/src/transforms/coerceDefaultEnumValues.ts
@@ -57,11 +57,11 @@ export function coerceDefaultEnumValues(
     return visit(def, {
       [Kind.INPUT_VALUE_DEFINITION](node) {
         if (node.defaultValue == null) {
-          return node;
+          return undefined;
         }
         const coerced = coercer.coerce(node.type, node.defaultValue);
         if (coerced == null) {
-          return node;
+          return undefined;
         }
         return { ...node, defaultValue: coerced };
       },

--- a/src/transforms/mergeExtensions.ts
+++ b/src/transforms/mergeExtensions.ts
@@ -40,6 +40,9 @@ export function mergeExtensions(doc: DocumentNode): DocumentNode {
   return visit(sansExtensions, {
     ObjectTypeDefinition(t) {
       const extensions = fields.get(t.name.value);
+      if (extensions.length === 0) {
+        return undefined;
+      }
       if (t.fields == null) {
         return { ...t, fields: extensions };
       }
@@ -47,6 +50,9 @@ export function mergeExtensions(doc: DocumentNode): DocumentNode {
     },
     InterfaceTypeDefinition(t) {
       const extensions = fields.get(t.name.value);
+      if (extensions.length === 0) {
+        return undefined;
+      }
       if (t.fields == null) {
         return { ...t, fields: extensions };
       }

--- a/src/transforms/resolveResolverParams.ts
+++ b/src/transforms/resolveResolverParams.ts
@@ -67,11 +67,13 @@ class ResolverParamsResolver {
     return ok(nextDefinitions);
   }
 
-  private transformField(field: FieldDefinitionNode): FieldDefinitionNode {
+  private transformField(
+    field: FieldDefinitionNode,
+  ): FieldDefinitionNode | undefined {
     const resolver = nullThrows(field.resolver);
 
     if (resolver.kind === "property" || resolver.arguments == null) {
-      return field;
+      return undefined;
     }
 
     // Resolve all the params individually
@@ -99,7 +101,7 @@ class ResolverParamsResolver {
           ),
         ]),
       );
-      return field;
+      return undefined;
     }
 
     const fieldArgs: InputValueDefinitionNode[] =

--- a/src/transforms/resolveTypes.ts
+++ b/src/transforms/resolveTypes.ts
@@ -106,11 +106,11 @@ class TemplateExtractor {
    */
   materializeTemplatesForNode<N extends ASTNode>(node: N): N {
     return visit(node, {
-      [Kind.NAME]: (node): NameNode => {
+      [Kind.NAME]: (node): NameNode | undefined => {
         const referenceNode = this.getReferenceNode(node);
-        if (referenceNode == null) return node;
+        if (referenceNode == null) return undefined;
         const name = this.resolveTypeReferenceOrReport(referenceNode);
-        if (name == null) return node;
+        if (name == null) return undefined;
         return { ...node, value: name };
       },
     });
@@ -216,16 +216,16 @@ class TemplateExtractor {
     const renamedDefinition = renameDefinition(original, derivedName, gqlLoc);
 
     const definition = visit(renamedDefinition, {
-      [Kind.NAMED_TYPE]: (node): NamedTypeNode => {
+      [Kind.NAMED_TYPE]: (node): NamedTypeNode | undefined => {
         const referenceNode = this.getReferenceNode(node.name);
-        if (referenceNode == null) return node;
+        if (referenceNode == null) return undefined;
 
         const name = this.resolveTypeReferenceOrReport(
           referenceNode,
           genericsContext,
         );
 
-        if (name == null) return node;
+        if (name == null) return undefined;
 
         return { ...node, name: { ...node.name, value: name } };
       },

--- a/src/validations/validateAsyncIterable.ts
+++ b/src/validations/validateAsyncIterable.ts
@@ -45,7 +45,7 @@ export function validateAsyncIterable(
 
     if (inner.kind !== Kind.LIST_TYPE || !inner.isAsyncIterable) {
       errors.push(gqlErr(field.type, E.subscriptionFieldNotAsyncIterable()));
-      return field;
+      return undefined;
     }
 
     const itemType = inner.type;


### PR DESCRIPTION
Graphql-js has a faster path if you return undefined. Without that, it will recreate the parent object and re-assign the unmodified as if it were a new node.

To profile I used our new profile tool which creates a project with 10,000 types.

## Before

Grats completed in: 9.954s
Grats completed in: 9.967s
Grats completed in: 9.578s
Grats completed in: 9.609s

## After

Grats completed in: 9.090s
Grats completed in: 8.969s
Grats completed in: 9.007s
Grats completed in: 9.035s

This saves us on the order of 5-10%