### PR TITLE
Add --fix flag

### DIFF
--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -243,16 +243,7 @@ class Extractor {
               this.hasTag(node, SUBSCRIPTION_FIELD_TAG)
             )
           ) {
-            this.report(
-              tag.tagName,
-              E.killsParentOnExceptionOnWrongNode(),
-              [],
-              {
-                fixName: "remove-kills-parent-on-exception",
-                description: "Remove @killsParentOnException tag",
-                changes: [Act.removeNode(tag)],
-              },
-            );
+            this.report(tag.tagName, E.killsParentOnExceptionOnWrongNode(), []);
           }
           // TODO: Report invalid location as well
           break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,9 +42,9 @@ program
   .option("--fix", "Automatically fix fixable diagnostics")
   .action(async ({ tsconfig, watch, fix }) => {
     if (watch) {
-      startWatchMode(tsconfig, { fix });
+      startWatchMode(tsconfig, { fix, log: console.error });
     } else {
-      runBuild(tsconfig, { fix });
+      runBuild(tsconfig, { fix, log: console.error });
     }
   });
 
@@ -122,7 +122,7 @@ function startWatchMode(tsconfig: string, options: BuildOptions) {
     lastRunCache = runCache;
 
     function fixOrReport(diagnostics: ts.Diagnostic[]) {
-      if (options.fix && applyFixes(diagnostics)) {
+      if (options.fix && applyFixes(diagnostics, options)) {
         // Watch mode should re-run after applying fixes
         return;
       }

--- a/src/fixFixable.ts
+++ b/src/fixFixable.ts
@@ -1,0 +1,140 @@
+import * as ts from "typescript";
+import {
+  DiagnosticsWithoutLocationResult,
+  FixableDiagnostic,
+} from "./utils/DiagnosticError";
+import { writeFileSync, readFileSync } from "fs";
+import { relativePath } from "./gratsRoot";
+
+export type FixOptions = {
+  fix: boolean;
+};
+
+/**
+ * Apply fixes repeatedly until all fixable diagnostics are resolved or no more fixes can be applied.
+ * Returns ok if all errors were fixed, err if some unfixable errors remain.
+ * If options.fix is false, just runs the function once without any fixing.
+ */
+export function withFixesFixed<T>(
+  resultFn: () => DiagnosticsWithoutLocationResult<T>,
+  options: FixOptions,
+): DiagnosticsWithoutLocationResult<T> {
+  if (!options.fix) {
+    return resultFn();
+  }
+
+  let totalFixesApplied = 0;
+  const maxIterations = 10;
+
+  for (let iteration = 0; iteration <= maxIterations; iteration++) {
+    if (iteration > 0) {
+      console.error(
+        `\nGrats: Re-running with fixes applied (iteration ${iteration})...\n`,
+      );
+    }
+    const result = resultFn();
+
+    if (result.kind === "OK") {
+      if (totalFixesApplied > 0 && iteration > 2) {
+        const fixes = totalFixesApplied === 1 ? "fix" : "fixes total";
+        console.error(`Grats: Applied ${totalFixesApplied} ${fixes}.`);
+      }
+      return result;
+    }
+
+    // Extract fixable diagnostics
+    const fixableDiagnostics = result.err.filter(
+      (d) => "fix" in d && d.fix != null,
+    );
+
+    if (fixableDiagnostics.length === 0) {
+      // No fixable diagnostics, return the error result
+      return result;
+    }
+
+    const issues = fixableDiagnostics.length === 1 ? "issue" : "issues";
+    console.error(
+      `Grats: Identified ${fixableDiagnostics.length} fixable ${issues}:`,
+    );
+
+    // Apply fixes
+    applyFixes(fixableDiagnostics);
+    totalFixesApplied += fixableDiagnostics.length;
+  }
+
+  // If we reach here, we've hit max iterations - return the last result
+  console.error(
+    `Grats: Reached maximum iterations (${maxIterations}). Some issues may remain.`,
+  );
+  return resultFn();
+}
+
+/**
+ * Apply fixes to source files and return the set of files that were changed.
+ *
+ * Returns true if any files were changed, false otherwise.
+ */
+export function applyFixes(fixableDiagnostics: FixableDiagnostic[]): boolean {
+  let appliedAnyFixes = false;
+
+  // Group diagnostics by file to batch changes
+  const diagnosticsByFile = new Map<string, FixableDiagnostic[]>();
+
+  for (const diagnostic of fixableDiagnostics) {
+    if (!diagnostic.fix) continue;
+
+    for (const change of diagnostic.fix.changes) {
+      const fileName = change.fileName;
+      if (!diagnosticsByFile.has(fileName)) {
+        diagnosticsByFile.set(fileName, []);
+      }
+      diagnosticsByFile.get(fileName)!.push(diagnostic);
+    }
+  }
+
+  // Apply changes to each file
+  for (const [fileName, fileDiagnostics] of diagnosticsByFile.entries()) {
+    try {
+      const content = readFileSync(fileName, "utf8");
+      let newContent = content;
+
+      // Collect all text changes for this file and sort by position in reverse order
+      const allTextChanges: { change: ts.TextChange; description: string }[] =
+        [];
+
+      for (const diagnostic of fileDiagnostics) {
+        if (!diagnostic.fix) continue;
+
+        const description = diagnostic.fix.description;
+        for (const fileChange of diagnostic.fix.changes) {
+          if (fileChange.fileName === fileName) {
+            for (const textChange of fileChange.textChanges) {
+              allTextChanges.push({ change: textChange, description });
+            }
+          }
+        }
+      }
+
+      // Sort changes by position in reverse order to avoid offset issues
+      allTextChanges.sort((a, b) => b.change.span.start - a.change.span.start);
+
+      // Apply each change and log it
+      for (const { change, description } of allTextChanges) {
+        const before = newContent.slice(0, change.span.start);
+        const after = newContent.slice(change.span.start + change.span.length);
+        newContent = before + change.newText + after;
+
+        console.error(
+          `  * Applied fix "${description}" in ${relativePath(fileName)}`,
+        );
+      }
+
+      writeFileSync(fileName, newContent, "utf8");
+      appliedAnyFixes = true;
+    } catch (error) {
+      console.error(`Grats: Failed to apply fix to ${fileName}:`, error);
+    }
+  }
+
+  return appliedAnyFixes;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./lib";
 // Used by the experimental TypeScript plugin
 export { extract } from "./Extractor";
 export { codegen } from "./codegen/schemaCodegen";
+export { ReportableDiagnostics } from "./utils/DiagnosticError";
 
 // #FIXME: Report diagnostics instead of throwing!
 export function getParsedTsConfig(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import * as ts from "typescript";
 import { ParsedCommandLineGrats, validateGratsOptions } from "./gratsConfig";
-import { ReportableDiagnostics } from "./utils/DiagnosticError";
+import { DiagnosticsWithoutLocationResult } from "./utils/DiagnosticError";
 import { err, ok } from "./utils/Result";
-import { Result } from "./utils/Result";
 
 export { printSDLWithoutMetadata } from "./printSchema";
 export * from "./Types";
@@ -14,7 +13,7 @@ export { codegen } from "./codegen/schemaCodegen";
 // #FIXME: Report diagnostics instead of throwing!
 export function getParsedTsConfig(
   configFile: string,
-): Result<ParsedCommandLineGrats, ReportableDiagnostics> {
+): DiagnosticsWithoutLocationResult<ParsedCommandLineGrats> {
   // https://github.com/microsoft/TypeScript/blob/46d70d79cd0dd00d19e4c617d6ebb25e9f3fc7de/src/compiler/watch.ts#L216
   const configFileHost: ts.ParseConfigFileHost = ts.sys as any;
   const parsed = ts.getParsedCommandLineOfConfigFile(
@@ -28,7 +27,7 @@ export function getParsedTsConfig(
   }
 
   if (parsed.errors.length > 0) {
-    return err(ReportableDiagnostics.fromDiagnostics(parsed.errors));
+    return err(parsed.errors);
   }
 
   return ok(validateGratsOptions(parsed));

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,12 +8,10 @@ import {
 } from "graphql";
 import {
   DiagnosticsWithoutLocationResult,
-  ReportableDiagnostics,
   graphQlErrorToDiagnostic,
 } from "./utils/DiagnosticError";
 import { concatResults, ResultPipe } from "./utils/Result";
 import { ok, err } from "./utils/Result";
-import { Result } from "./utils/Result";
 import * as ts from "typescript";
 import { ExtractionSnapshot } from "./Extractor";
 import { TypeContext } from "./TypeContext";
@@ -56,7 +54,7 @@ export type SchemaAndDoc = {
 // Exported for tests that want to intercept diagnostic errors.
 export function buildSchemaAndDocResult(
   options: ParsedCommandLineGrats,
-): Result<SchemaAndDoc, ReportableDiagnostics> {
+): DiagnosticsWithoutLocationResult<SchemaAndDoc> {
   // https://stackoverflow.com/a/66604532/1263117
   const compilerHost = ts.createCompilerHost(
     options.options,
@@ -70,15 +68,13 @@ export function buildSchemaAndDocResult(
 export function buildSchemaAndDocResultWithHost(
   options: ParsedCommandLineGrats,
   compilerHost: ts.CompilerHost,
-): Result<SchemaAndDoc, ReportableDiagnostics> {
+): DiagnosticsWithoutLocationResult<SchemaAndDoc> {
   const program = ts.createProgram(
     options.fileNames,
     options.options,
     compilerHost,
   );
-  return new ResultPipe(extractSchemaAndDoc(options, program))
-    .mapErr((e) => new ReportableDiagnostics(compilerHost, e))
-    .result();
+  return extractSchemaAndDoc(options, program);
 }
 
 /**

--- a/src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts.expected
@@ -69,3 +69,30 @@ src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts:12:26 - error: Ex
 -   hello3({ greeting }: { greeting: string | undefined }): string {
 +   hello3({ greeting }: { greeting?: string | undefined }): string {
       return "Hello world!";
+
+-- Applied Fixes --
+  * Applied fix "Make argument optional" in grats/src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts
+  * Applied fix "Make argument optional" in grats/src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts
+  * Applied fix "Make argument optional" in grats/src/tests/fixtures/arguments/NullableArgumentErrors.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class SomeType {
+  /** @gqlField */
+  hello1({ greeting }: { greeting?: string | null }): string {
+    return "Hello world!";
+  }
+  /** @gqlField */
+  hello2({ greeting }: { greeting?: string | void }): string {
+    return "Hello world!";
+  }
+  /** @gqlField */
+  hello3({ greeting }: { greeting?: string | undefined }): string {
+    return "Hello world!";
+  }
+  // TODO: This should be an error, but it's not.
+  /** @gqlField */
+  hello5({ greeting }: { greeting?: string | undefined }): string {
+    return "Hello world!";
+  }
+}

--- a/src/tests/fixtures/arguments/OptionalNonNullableArgument.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/OptionalNonNullableArgument.invalid.ts.expected
@@ -28,3 +28,15 @@ src/tests/fixtures/arguments/OptionalNonNullableArgument.invalid.ts:4:33 - error
 -   hello({ greeting }: { greeting?: string }): string {
 +   hello({ greeting }: { greeting?: string | null }): string {
       return `${greeting ?? "Hello"} World!`;
+
+-- Applied Fixes --
+  * Applied fix "Add '| null' to the type" in grats/src/tests/fixtures/arguments/OptionalNonNullableArgument.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class SomeType {
+  /** @gqlField */
+  hello({ greeting }: { greeting?: string | null }): string {
+    return `${greeting ?? "Hello"} World!`;
+  }
+}

--- a/src/tests/fixtures/arguments/PositionalArgOptionalNotNullable.invalid.ts.expected
+++ b/src/tests/fixtures/arguments/PositionalArgOptionalNotNullable.invalid.ts.expected
@@ -34,3 +34,21 @@ src/tests/fixtures/arguments/PositionalArgOptionalNotNullable.invalid.ts:10:17 -
 -   hello(greeting?: string): string {
 +   hello(greeting?: string | null): string {
       return `${greeting ?? "Hello"} World`;
+
+-- Applied Fixes --
+  * Applied fix "Add '| null' to the parameter type" in grats/src/tests/fixtures/arguments/PositionalArgOptionalNotNullable.invalid.ts
+
+-- Fixed Text --
+/** @gqlInput */
+type Greeting = {
+  name: string;
+  salutation: string;
+};
+
+/** @gqlType */
+export default class SomeType {
+  /** @gqlField */
+  hello(greeting?: string | null): string {
+    return `${greeting ?? "Hello"} World`;
+  }
+}

--- a/src/tests/fixtures/comments/detachedBlockCommentNotJSDocWithoutStar.invalid.ts.expected
+++ b/src/tests/fixtures/comments/detachedBlockCommentNotJSDocWithoutStar.invalid.ts.expected
@@ -26,3 +26,14 @@ src/tests/fixtures/comments/detachedBlockCommentNotJSDocWithoutStar.invalid.ts:2
 - /*
 + /**
      @gqlType
+
+-- Applied Fixes --
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/detachedBlockCommentNotJSDocWithoutStar.invalid.ts
+
+-- Fixed Text --
+/**
+   @gqlType
+*/
+/**
+ * Foo
+ */

--- a/src/tests/fixtures/comments/invalidTagInLinecomment.invalid.ts.expected
+++ b/src/tests/fixtures/comments/invalidTagInLinecomment.invalid.ts.expected
@@ -30,3 +30,14 @@ src/tests/fixtures/comments/invalidTagInLinecomment.invalid.ts:1:4 - error: Unex
 - // @gqlTyp
 + /** @gqlTyp */
   export default class Composer {
+
+-- Applied Fixes --
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/invalidTagInLinecomment.invalid.ts
+
+-- Fixed Text --
+/** @gqlTyp */
+export default class Composer {
+  url(): string {
+    return `/composer/`;
+  }
+}

--- a/src/tests/fixtures/comments/lineComment.invalid.ts.expected
+++ b/src/tests/fixtures/comments/lineComment.invalid.ts.expected
@@ -41,3 +41,16 @@ src/tests/fixtures/comments/lineComment.invalid.ts:3:6 - error: Unexpected Grats
 -   // @gqlField
 +   /** @gqlField */
     url(): string {
+
+-- Applied Fixes --
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/lineComment.invalid.ts
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/lineComment.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class Composer {
+  /** @gqlField */
+  url(): string {
+    return `/composer/`;
+  }
+}

--- a/src/tests/fixtures/comments/lineCommentWrongCasing.invalid.ts.expected
+++ b/src/tests/fixtures/comments/lineCommentWrongCasing.invalid.ts.expected
@@ -49,3 +49,16 @@ src/tests/fixtures/comments/lineCommentWrongCasing.invalid.ts:3:6 - error: Unexp
 -   // @gqlfield
 +   /** @gqlfield */
     url(): string {
+
+-- Applied Fixes --
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/lineCommentWrongCasing.invalid.ts
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/lineCommentWrongCasing.invalid.ts
+
+-- Fixed Text --
+/** @GQLtYPE */
+export default class Composer {
+  /** @gqlfield */
+  url(): string {
+    return `/composer/`;
+  }
+}

--- a/src/tests/fixtures/comments/nonJSDocBlockComment.invalid.ts.expected
+++ b/src/tests/fixtures/comments/nonJSDocBlockComment.invalid.ts.expected
@@ -25,3 +25,12 @@ src/tests/fixtures/comments/nonJSDocBlockComment.invalid.ts:3:4 - error: Unexpec
 - /* @gqlType */
 + /** @gqlType */
   class Composer {}
+
+-- Applied Fixes --
+  * Applied fix "Convert to a docblock comment" in grats/src/tests/fixtures/comments/nonJSDocBlockComment.invalid.ts
+
+-- Fixed Text --
+// Oops! Forgot to use two asterisks for the JSDoc block comment.
+
+/** @gqlType */
+class Composer {}

--- a/src/tests/fixtures/custom_scalars/SpecifiedByOldSyntax.invalid.ts.expected
+++ b/src/tests/fixtures/custom_scalars/SpecifiedByOldSyntax.invalid.ts.expected
@@ -29,3 +29,12 @@ src/tests/fixtures/custom_scalars/SpecifiedByOldSyntax.invalid.ts:3:4 - error: T
 -  */
 +  * @gqlAnnotate specifiedBy(url: "https://tools.ietf.org/html/rfc4122")*/
   export type UUID = string;
+
+-- Applied Fixes --
+  * Applied fix "Replace @specifiedBy with @gqlAnnotate" in grats/src/tests/fixtures/custom_scalars/SpecifiedByOldSyntax.invalid.ts
+
+-- Fixed Text --
+/**
+ * @gqlScalar
+ * @gqlAnnotate specifiedBy(url: "https://tools.ietf.org/html/rfc4122")*/
+export type UUID = string;

--- a/src/tests/fixtures/extend_type/fieldAsArrowFunctionNotExported.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/fieldAsArrowFunctionNotExported.invalid.ts.expected
@@ -30,3 +30,17 @@ src/tests/fixtures/extend_type/fieldAsArrowFunctionNotExported.invalid.ts:7:7 - 
 - const greeting = (_: SomeType): string => {
 + export const greeting = (_: SomeType): string => {
     return `Hello World`;
+
+-- Applied Fixes --
+  * Applied fix "Add export keyword to exported arrow function with @gqlField" in grats/src/tests/fixtures/extend_type/fieldAsArrowFunctionNotExported.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+class SomeType {
+  // No fields
+}
+
+/** @gqlField */
+export const greeting = (_: SomeType): string => {
+  return `Hello World`;
+};

--- a/src/tests/fixtures/extend_type/notExported.invalid.ts.expected
+++ b/src/tests/fixtures/extend_type/notExported.invalid.ts.expected
@@ -30,3 +30,17 @@ src/tests/fixtures/extend_type/notExported.invalid.ts:7:10 - error: Expected a `
 - function greeting(_: Query): string {
 + export function greeting(_: Query): string {
     return `Hello World`;
+
+-- Applied Fixes --
+  * Applied fix "Add export keyword to function with @gqlField" in grats/src/tests/fixtures/extend_type/notExported.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+class SomeType {
+  // No fields
+}
+
+/** @gqlField */
+export function greeting(_: Query): string {
+  return `Hello World`;
+}

--- a/src/tests/fixtures/field_definitions/FieldAsStaticClassMethodNotExported.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/FieldAsStaticClassMethodNotExported.invalid.ts.expected
@@ -41,3 +41,21 @@ src/tests/fixtures/field_definitions/FieldAsStaticClassMethodNotExported.invalid
 - class User {
 + export class User {
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Add export keyword to class with static @gqlField" in grats/src/tests/fixtures/field_definitions/FieldAsStaticClassMethodNotExported.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  /** @gqlField */
+  name: string;
+
+  /** @gqlField */
+  static getUser(_: Query): User {
+    return new User();
+  }
+}
+
+/** @gqlType */
+type Query = unknown;

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts.expected
@@ -32,3 +32,17 @@ Learn more: https://grats.capt.dev/docs/docblock-tags/fields#class-based-fields
 -     hello: string,
 +     public hello: string,
     ) {
+
+-- Applied Fixes --
+  * Applied fix "Add 'public' modifier" in grats/src/tests/fixtures/field_definitions/ParameterPropertyFieldNoModifier.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class SomeType {
+  constructor(
+    /** @gqlField */
+    public hello: string,
+  ) {
+    console.log(hello);
+  }
+}

--- a/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts.expected
@@ -33,3 +33,18 @@ Learn more: https://grats.capt.dev/docs/docblock-tags/fields#class-based-fields
 -     private readonly hello: string,
 +     public readonly hello: string,
     ) {}
+
+-- Applied Fixes --
+  * Applied fix "Make parameter property public" in grats/src/tests/fixtures/field_definitions/ParameterPropertyFieldReadOnlyPrivate.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class SomeType {
+  constructor(
+    /**
+     * Greet the world!
+     * @gqlField
+     */
+    public readonly hello: string,
+  ) {}
+}

--- a/src/tests/fixtures/field_definitions/asyncFunctionFieldNotExported.invalid.ts.expected
+++ b/src/tests/fixtures/field_definitions/asyncFunctionFieldNotExported.invalid.ts.expected
@@ -28,3 +28,15 @@ src/tests/fixtures/field_definitions/asyncFunctionFieldNotExported.invalid.ts:2:
 - async function greet(_: Query): Promise<string> {
 + export async function greet(_: Query): Promise<string> {
     return "Hello, World!";
+
+-- Applied Fixes --
+  * Applied fix "Add export keyword to function with @gqlField" in grats/src/tests/fixtures/field_definitions/asyncFunctionFieldNotExported.invalid.ts
+
+-- Fixed Text --
+/** @gqlField */
+export async function greet(_: Query): Promise<string> {
+  return "Hello, World!";
+}
+
+/** @gqlType */
+type Query = unknown;

--- a/src/tests/fixtures/input_type_one_of/simpleOneOfDeprecatedTag.invalid.ts.expected
+++ b/src/tests/fixtures/input_type_one_of/simpleOneOfDeprecatedTag.invalid.ts.expected
@@ -29,3 +29,12 @@ src/tests/fixtures/input_type_one_of/simpleOneOfDeprecatedTag.invalid.ts:3:4 - e
 -  */
 +  * */
   export type Greeting = { firstName: string } | { lastName: string };
+
+-- Applied Fixes --
+  * Applied fix "Remove @oneOf tag" in grats/src/tests/fixtures/input_type_one_of/simpleOneOfDeprecatedTag.invalid.ts
+
+-- Fixed Text --
+/**
+ * @gqlInput
+ * */
+export type Greeting = { firstName: string } | { lastName: string };

--- a/src/tests/fixtures/input_types/inputFieldWithGqlField.invalid.ts.expected
+++ b/src/tests/fixtures/input_types/inputFieldWithGqlField.invalid.ts.expected
@@ -26,3 +26,13 @@ src/tests/fixtures/input_types/inputFieldWithGqlField.invalid.ts:3:7 - error: Th
 -   /** @gqlField */
 +   
     name: string;
+
+-- Applied Fixes --
+  * Applied fix "Remove @gqlField tag" in grats/src/tests/fixtures/input_types/inputFieldWithGqlField.invalid.ts
+
+-- Fixed Text --
+/** @gqlInput */
+type Foo = {
+  
+  name: string;
+};

--- a/src/tests/fixtures/typename/PropertySignatureTypenameIncorrectName.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertySignatureTypenameIncorrectName.invalid.ts.expected
@@ -33,3 +33,20 @@ src/tests/fixtures/typename/PropertySignatureTypenameIncorrectName.invalid.ts:3:
 -   __typename: "Group";
 +   __typename: "User";
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` type" in grats/src/tests/fixtures/typename/PropertySignatureTypenameIncorrectName.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User implements IPerson {
+  __typename: "User";
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlInterface */
+export interface IPerson {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/typename/PropertySignatureTypenameMissingType.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertySignatureTypenameMissingType.invalid.ts.expected
@@ -33,3 +33,20 @@ src/tests/fixtures/typename/PropertySignatureTypenameMissingType.invalid.ts:3:3 
 -   __typename;
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertySignatureTypenameMissingType.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User implements IPerson {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlInterface */
+export interface IPerson {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/typename/PropertySignatureTypenameNonLiteralType.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertySignatureTypenameNonLiteralType.invalid.ts.expected
@@ -33,3 +33,20 @@ src/tests/fixtures/typename/PropertySignatureTypenameNonLiteralType.invalid.ts:3
 -   __typename: string;
 +   __typename: "User";
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` type" in grats/src/tests/fixtures/typename/PropertySignatureTypenameNonLiteralType.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User implements IPerson {
+  __typename: "User";
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlInterface */
+export interface IPerson {
+  /** @gqlField */
+  name: string;
+}

--- a/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchClassName.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchClassName.invalid.ts.expected
@@ -27,3 +27,14 @@ src/tests/fixtures/typename/PropertyTypenameDoesNotMatchClassName.invalid.ts:3:1
 -   __typename = "Group" as const;
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchClassName.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string = "Alice";
+}

--- a/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchDeclaredName.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchDeclaredName.invalid.ts.expected
@@ -27,3 +27,14 @@ src/tests/fixtures/typename/PropertyTypenameDoesNotMatchDeclaredName.invalid.ts:
 -   __typename = "UserModel" as const;
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertyTypenameDoesNotMatchDeclaredName.invalid.ts
+
+-- Fixed Text --
+/** @gqlType User */
+export class UserModel {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string = "Alice";
+}

--- a/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsConst.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsConst.invalid.ts.expected
@@ -27,3 +27,14 @@ src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsConst.invalid.
 -   __typename = "User";
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsConst.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string = "Alice";
+}

--- a/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsExactlyConst.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsExactlyConst.invalid.ts.expected
@@ -29,3 +29,16 @@ src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsExactlyConst.i
 -   __typename = "User" as Foo;
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertyTypenameMustNeedToBeDeclaredAsExactlyConst.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string = "Alice";
+}
+
+type Foo = string;

--- a/src/tests/fixtures/typename/PropertyTypenameNoInitializer.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameNoInitializer.invalid.ts.expected
@@ -27,3 +27,14 @@ src/tests/fixtures/typename/PropertyTypenameNoInitializer.invalid.ts:3:15 - erro
 -   __typename: string;
 +   __typename: "User";
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` type" in grats/src/tests/fixtures/typename/PropertyTypenameNoInitializer.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  __typename: "User";
+  /** @gqlField */
+  name: string = "Alice";
+}

--- a/src/tests/fixtures/typename/PropertyTypenameNonStringInitializer.invalid.ts.expected
+++ b/src/tests/fixtures/typename/PropertyTypenameNonStringInitializer.invalid.ts.expected
@@ -27,3 +27,14 @@ src/tests/fixtures/typename/PropertyTypenameNonStringInitializer.invalid.ts:3:16
 -   __typename = 1 as const;
 +   __typename = "User" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/typename/PropertyTypenameNonStringInitializer.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export class User {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string = "Alice";
+}

--- a/src/tests/fixtures/unions/UnionAsMemberOfItself.invalid.ts.expected
+++ b/src/tests/fixtures/unions/UnionAsMemberOfItself.invalid.ts.expected
@@ -57,3 +57,31 @@ src/tests/fixtures/unions/UnionAsMemberOfItself.invalid.ts:16:16 - error: Expect
 -   __typename = "Entity";
 +   __typename = "Entity" as const;
     /** @gqlField */
+
+-- Applied Fixes --
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/unions/UnionAsMemberOfItself.invalid.ts
+  * Applied fix "Create Grats-compatible `__typename` property" in grats/src/tests/fixtures/unions/UnionAsMemberOfItself.invalid.ts
+
+-- Fixed Text --
+/** @gqlType */
+export default class SomeType {
+  /** @gqlField */
+  me: Actor;
+}
+
+/** @gqlType */
+class User {
+  __typename = "User" as const;
+  /** @gqlField */
+  name: string;
+}
+
+/** @gqlType */
+class Entity {
+  __typename = "Entity" as const;
+  /** @gqlField */
+  description: string;
+}
+
+/** @gqlUnion */
+type Actor = User | Entity | Actor;

--- a/src/tests/fixtures/user_error/DuplicateOneOfTag.invalid.ts.expected
+++ b/src/tests/fixtures/user_error/DuplicateOneOfTag.invalid.ts.expected
@@ -38,3 +38,15 @@ src/tests/fixtures/user_error/DuplicateOneOfTag.invalid.ts:3:4 - error: Unexpect
 -  */
 +  * */
   type Foo = {
+
+-- Applied Fixes --
+  * Applied fix "Remove duplicate @oneOf tag" in grats/src/tests/fixtures/user_error/DuplicateOneOfTag.invalid.ts
+
+-- Fixed Text --
+/**
+ * @gqlInput
+ * @oneOf
+ * */
+type Foo = {
+  a: string;
+};

--- a/src/tests/fixtures/user_error/KillsParentOnExceptionOnNonField.invalid.ts.expected
+++ b/src/tests/fixtures/user_error/KillsParentOnExceptionOnNonField.invalid.ts.expected
@@ -13,18 +13,8 @@ type Foo = {
 -----------------
 OUTPUT
 -----------------
--- Error Report --
 src/tests/fixtures/user_error/KillsParentOnExceptionOnNonField.invalid.ts:1:6 - error: Unexpected `@killsParentOnException`. `@killsParentOnException` can only be used in field annotation docblocks. Perhaps you are missing a `@gqlField` tag?
 
 1 /** @killsParentOnException */
        ~~~~~~~~~~~~~~~~~~~~~~
 
-
--- Code Action: "Remove @killsParentOnException tag" (remove-kills-parent-on-exception) --
-- Original
-+ Fixed
-
-@@ -1,2 +1,2 @@
-- /** @killsParentOnException */
-+ /** */
-  const foo = "bar";

--- a/src/tests/fixtures/user_error/WrongCaseGqlTag.invalid.ts.expected
+++ b/src/tests/fixtures/user_error/WrongCaseGqlTag.invalid.ts.expected
@@ -22,3 +22,10 @@ src/tests/fixtures/user_error/WrongCaseGqlTag.invalid.ts:1:6 - error: Incorrect 
 - /** @GQLField */
 + /** @gqlField */
   function field() {}
+
+-- Applied Fixes --
+  * Applied fix "Change to @gqlField" in grats/src/tests/fixtures/user_error/WrongCaseGqlTag.invalid.ts
+
+-- Fixed Text --
+/** @gqlField */
+function field() {}

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -134,7 +134,12 @@ const testDirs = [
         compilerHost,
       );
       if (schemaResult.kind === "ERROR") {
-        return err(formatDiagnosticsWithContext(code, schemaResult.err));
+        return err(
+          formatDiagnosticsWithContext(
+            code,
+            ReportableDiagnostics.fromDiagnostics(schemaResult.err),
+          ),
+        );
       }
 
       const { schema, doc, resolvers } = schemaResult.value;
@@ -220,7 +225,11 @@ const testDirs = [
       });
       const schemaResult = buildSchemaAndDocResult(parsedOptions);
       if (schemaResult.kind === "ERROR") {
-        throw new Error(schemaResult.err.formatDiagnosticsWithContext());
+        throw new Error(
+          ReportableDiagnostics.fromDiagnostics(
+            schemaResult.err,
+          ).formatDiagnosticsWithContext(),
+        );
       }
 
       const { schema, doc, resolvers } = schemaResult.value;

--- a/src/utils/DiagnosticError.ts
+++ b/src/utils/DiagnosticError.ts
@@ -2,7 +2,7 @@ import { GraphQLError, Location, Source } from "graphql";
 import * as ts from "typescript";
 import { Result } from "./Result";
 
-type FixableDiagnostic = ts.Diagnostic & {
+export type FixableDiagnostic = ts.Diagnostic & {
   fix?: ts.CodeFixAction;
 };
 export type FixableDiagnosticWithLocation = ts.DiagnosticWithLocation & {

--- a/website/docs/01-getting-started/02-cli.md
+++ b/website/docs/01-getting-started/02-cli.md
@@ -22,6 +22,25 @@ Or, if you want to leave Grats running while you work, you can use the `--watch`
 npx grats --watch
 ```
 
+### Automatic Fixes
+
+Grats can automatically fix certain issues it detects in your code. Use the `--fix` flag to enable automatic fixing:
+
+```bash
+npx grats --fix
+```
+
+This will automatically apply fixes for issues like:
+
+- Incorrect casing in docblock tags (e.g., `@gqltype` → `@gqlType`)
+- Deprecated docblock tags that have replacements
+
+The `--fix` flag can also be combined with `--watch` mode:
+
+```bash
+npx grats --watch --fix
+```
+
 ### Options
 
 ```
@@ -33,6 +52,7 @@ Options:
   -V, --version              output the version number
   --tsconfig <TSCONFIG>      Path to tsconfig.json. Defaults to auto-detecting based on the current working directory
   --watch                    Watch for changes and rebuild schema files as needed
+  --fix                      Automatically fix fixable diagnostics
   -h, --help                 display help for command
 
 Commands:

--- a/website/docs/07-changelog/index.md
+++ b/website/docs/07-changelog/index.md
@@ -5,6 +5,7 @@
 Changes in this section are not yet released. If you need access to these changes before we cut a release, check out our `@main` NPM releases. Each commit on the main branch is [published to NPM](https://www.npmjs.com/package/grats?activeTab=versions) under the `main` tag.
 
 - **Features**
+  - Added `--fix` flag to automatically fix fixable diagnostics. The CLI can now automatically apply fixes for common issues like incorrect casing in docblock tags and deprecated tag usage. The `--fix` flag works with both single builds and watch mode.
   - Built-in support for serialization/parsing of custom scalars. Grats' generated `getSchema` function now requires a config object which can include serialization/parsing functions for any custom scalars defined in your schema. See [the docs](https://grats.capt.dev/docs/docblock-tags/scalars/#serialization-and-parsing-of-custom-scalars) for details.
 
 - **Performance**

--- a/website/scripts/gratsCode.ts
+++ b/website/scripts/gratsCode.ts
@@ -1,6 +1,11 @@
 import fs from "fs";
-import { buildSchemaAndDocResult, codegen } from "grats";
-import { printSDLWithoutMetadata, GratsConfig } from "grats";
+import { buildSchemaAndDocResult } from "grats/src/lib";
+import { codegen } from "grats/src/codegen/schemaCodegen";
+import { printSDLWithoutMetadata } from "grats/src/printSchema";
+import { ReportableDiagnostics } from "grats/src/utils/DiagnosticError";
+import type { GratsConfig } from "grats/src/gratsConfig";
+// Import to ensure GraphQL AST extensions are loaded
+import "grats/src/GraphQLAstExtensions";
 import glob from "glob";
 
 async function main() {
@@ -39,7 +44,8 @@ function processFile(file: string) {
   };
   const schemaAndDocResult = buildSchemaAndDocResult(parsedOptions);
   if (schemaAndDocResult.kind === "ERROR") {
-    const errors = schemaAndDocResult.err.formatDiagnosticsWithContext();
+    const reportableDiagnostics = ReportableDiagnostics.fromDiagnostics(schemaAndDocResult.err);
+    const errors = reportableDiagnostics.formatDiagnosticsWithContext();
     console.error(errors);
     throw new Error("Invalid grats code");
   }

--- a/website/scripts/gratsCode.ts
+++ b/website/scripts/gratsCode.ts
@@ -1,11 +1,11 @@
 import fs from "fs";
-import { buildSchemaAndDocResult } from "grats/src/lib";
-import { codegen } from "grats/src/codegen/schemaCodegen";
-import { printSDLWithoutMetadata } from "grats/src/printSchema";
-import { ReportableDiagnostics } from "grats/src/utils/DiagnosticError";
-import type { GratsConfig } from "grats/src/gratsConfig";
-// Import to ensure GraphQL AST extensions are loaded
-import "grats/src/GraphQLAstExtensions";
+import {
+  buildSchemaAndDocResult,
+  codegen,
+  printSDLWithoutMetadata,
+  ReportableDiagnostics,
+  type GratsConfig,
+} from "grats";
 import glob from "glob";
 
 async function main() {
@@ -44,7 +44,9 @@ function processFile(file: string) {
   };
   const schemaAndDocResult = buildSchemaAndDocResult(parsedOptions);
   if (schemaAndDocResult.kind === "ERROR") {
-    const reportableDiagnostics = ReportableDiagnostics.fromDiagnostics(schemaAndDocResult.err);
+    const reportableDiagnostics = ReportableDiagnostics.fromDiagnostics(
+      schemaAndDocResult.err,
+    );
     const errors = reportableDiagnostics.formatDiagnosticsWithContext();
     console.error(errors);
     throw new Error("Invalid grats code");


### PR DESCRIPTION
For a while now several Grats errors have included auto fix options, but they are only exposed in the playground and via the experimental TypeScript plugin. This PR adds a new `--fix` flag at the cli for either regular builds or watch mode which will auto apply fixes that are safe to apply automatically.

Some examples:

* Forgetting to export a class/function
* Forgetting to add (or incorrectly defining) __typename to a class that implements an interface
* Incorrect casing used in `@gql*` tags 

https://github.com/user-attachments/assets/668a2c87-78cb-4582-ae4b-3c4939707e3f

