### PR TITLE
Fix crash on invalid directive locations in playground

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -14,6 +14,7 @@ import {
   INFO_TAG,
   DIRECTIVE_TAG,
 } from "./Extractor.js";
+import { DirectiveLocation } from "graphql";
 
 export const ISSUE_URL = "https://github.com/captbaritone/grats/issues";
 
@@ -652,6 +653,10 @@ export function specifiedByDeprecated() {
 
 export function directiveTagNoComment() {
   return "Expected `@gqlDirective` tag to specify at least one location.";
+}
+
+export function invalidDirectiveLocation(name: string) {
+  return `"${name}" is not a valid directive location. Valid locations are: ${Object.values(DirectiveLocation).join(", ")}.`;
 }
 
 export function directiveFunctionNotNamed() {

--- a/src/Extractor.ts
+++ b/src/Extractor.ts
@@ -17,7 +17,7 @@ import {
   DefinitionNode,
   version as graphqlJSVersion,
   TokenKind,
-  GraphQLError,
+  DirectiveLocation,
 } from "graphql";
 import { gte as semverGte } from "semver";
 import {
@@ -536,12 +536,20 @@ class Extractor {
       }
 
       const locations = parser
-        .delimitedMany(TokenKind.PIPE, () => parser.parseDirectiveLocation())
+        .delimitedMany(TokenKind.PIPE, () => parser.parseName())
         .map((location) => ({ ...location, loc: loc(tag) }));
       return { name, repeatable, locations };
     });
 
     if (tagData == null) return;
+
+    const validLocations = Object.values(DirectiveLocation) as string[];
+    for (const location of tagData.locations) {
+      if (!validLocations.includes(location.value)) {
+        this.report(tag, E.invalidDirectiveLocation(location.value));
+        return;
+      }
+    }
 
     let name = tagData.name;
 
@@ -909,7 +917,11 @@ class Extractor {
       parser.expectToken(TokenKind.EOF);
       return result;
     } catch (err) {
-      if (err instanceof GraphQLError) {
+      if (err instanceof Error && err.name === "GraphQLError") {
+        // Note: We use a name check instead of `instanceof GraphQLError`
+        // because in bundled environments (e.g. the playground), the
+        // GraphQLError class from the parser may be a different instance
+        // than the one we imported, causing `instanceof` to fail.
         this.report(node, err.message);
       } else {
         throw err;

--- a/src/tests/fixtures/directives/defineCustomDirectiveLocationInvalid.invalid.ts.expected.md
+++ b/src/tests/fixtures/directives/defineCustomDirectiveLocationInvalid.invalid.ts.expected.md
@@ -15,7 +15,7 @@ export function customDirective() {}
 ### Error Report
 
 ```text
-src/tests/fixtures/directives/defineCustomDirectiveLocationInvalid.invalid.ts:3:4 - error: Syntax Error: Unexpected Name "WHOOPS".
+src/tests/fixtures/directives/defineCustomDirectiveLocationInvalid.invalid.ts:3:4 - error: "WHOOPS" is not a valid directive location. Valid locations are: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION, SCHEMA, SCALAR, OBJECT, FIELD_DEFINITION, ARGUMENT_DEFINITION, INTERFACE, UNION, ENUM, ENUM_VALUE, INPUT_OBJECT, INPUT_FIELD_DEFINITION.
 
 3  * @gqlDirective on WHOOPS
      ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/tests/fixtures/directives/directiveOnDirectiveDefinitionLocation.invalid.ts
+++ b/src/tests/fixtures/directives/directiveOnDirectiveDefinitionLocation.invalid.ts
@@ -1,0 +1,8 @@
+import { Int } from "../../../Types";
+/**
+ * @gqlDirective on DIRECTIVE_DEFINITION
+ * @gqlAnnotate
+ */
+export function myDirective(args: { credits: Int }) {
+  // ...
+}

--- a/src/tests/fixtures/directives/directiveOnDirectiveDefinitionLocation.invalid.ts.expected.md
+++ b/src/tests/fixtures/directives/directiveOnDirectiveDefinitionLocation.invalid.ts.expected.md
@@ -1,0 +1,27 @@
+# directives/directiveOnDirectiveDefinitionLocation.invalid.ts
+
+## Input
+
+```ts title="directives/directiveOnDirectiveDefinitionLocation.invalid.ts"
+import { Int } from "../../../Types";
+/**
+ * @gqlDirective on DIRECTIVE_DEFINITION
+ * @gqlAnnotate
+ */
+export function myDirective(args: { credits: Int }) {
+  // ...
+}
+```
+
+## Output
+
+### Error Report
+
+```text
+src/tests/fixtures/directives/directiveOnDirectiveDefinitionLocation.invalid.ts:3:4 - error: "DIRECTIVE_DEFINITION" is not a valid directive location. Valid locations are: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION, SCHEMA, SCALAR, OBJECT, FIELD_DEFINITION, ARGUMENT_DEFINITION, INTERFACE, UNION, ENUM, ENUM_VALUE, INPUT_OBJECT, INPUT_FIELD_DEFINITION.
+
+3  * @gqlDirective on DIRECTIVE_DEFINITION
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+4  * @gqlAnnotate
+  ~~~
+```


### PR DESCRIPTION
## Summary
- The playground crashed with an unhandled `GraphQLError` when using invalid directive locations like `DIRECTIVE_DEFINITION`, because `instanceof GraphQLError` failed in the bundled environment (duplicate module instances)
- Replaced `parser.parseDirectiveLocation()` with manual `parseName()` + validation against the `DirectiveLocation` enum, and switched to `err.name === "GraphQLError"` check for robustness
- Added a better error message listing all valid directive locations

## Test plan
- [x] Added test fixture `directiveOnDirectiveDefinitionLocation.invalid.ts`
- [x] Updated existing `defineCustomDirectiveLocationInvalid` snapshot with improved error message
- [x] All tests pass
- [x] Verified fix in local playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)