### PR TITLE
Upgrade commander to v15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node-version: &node-versions
-          - 20.x # LTS
           - 22.x # LTS
           - 24.x # LTS
     steps:
@@ -112,10 +111,10 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 9.3.0
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - name: Ensure npm 11.5.1 or later for trusted publishing

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "profile": "tsx scripts/profile.ts"
   },
   "dependencies": {
-    "commander": "^14.0.1",
+    "commander": "^15.0.0",
     "graphql": "^16.11.0",
     "semver": "^7.7.2"
   },
@@ -49,7 +49,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22.12 <=24"
   },
   "bugs": {
     "url": "https://github.com/captbaritone/grats/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       commander:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^15.0.0
+        version: 15.0.0
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
@@ -3700,9 +3700,9 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
-  commander@14.0.1:
-    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -12222,7 +12222,7 @@ snapshots:
 
   commander@10.0.1: {}
 
-  commander@14.0.1: {}
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 

--- a/website/docs/07-changelog/index.md
+++ b/website/docs/07-changelog/index.md
@@ -4,9 +4,12 @@
 
 Changes in this section are not yet released. If you need access to these changes before we cut a release, check out our `@main` NPM releases. Each commit on the main branch is [published to NPM](https://www.npmjs.com/package/grats?activeTab=versions) under the `main` tag.
 
+- **Breaking Changes**
+  - Grats now requires Node.js `>=22.12.0` (previously `>=20`). This is a result of upgrading `commander` to `v15`, which dropped support for older Node.js versions.
 - **Features**
   - Added support for deriving `@gqlEnum` from const arrays (`(typeof X)[number]`) and const objects (`(typeof X)[keyof typeof X]`). This allows defining enums with runtime-accessible values without using TypeScript's `enum` syntax. The const declaration must immediately precede the type alias. See [enum docs](../04-docblock-tags/07-enums.mdx#runtime-accessible-enums) for details.
 - **Improvements**
+  - Upgraded `commander` from `v14` to `v15`.
   - `typescript` is now a peer dependency (`>=5.5`) instead of a direct dependency, allowing you to use your own TypeScript version. ([PR](https://github.com/captbaritone/grats/pull/228))
   - Added support for TypeScript 6.0. ([PR](https://github.com/captbaritone/grats/pull/228))
   - CI now tests against TypeScript 5.5, 5.7, 5.9, and 6.0.


### PR DESCRIPTION
## Summary

Upgrades `commander` from v14 to **v15**.

Commander v15 dropped support for Node.js `< 22.12.0`, so this bumps Grats' minimum Node version accordingly.

## Changes
- **`package.json`**: `commander` → `^15.0.0`; `engines.node` → `>=22.12 <=24`
- **`pnpm-lock.yaml`**: updated to commander `15.0.0`
- **`.github/workflows/ci.yaml`**: dropped Node `20.x` from the test matrix; publish job moved from Node `20.x` → `22.x`
- **changelog**: added a **Breaking Changes** note (min Node is now `>=22.12.0`) and an Improvements note for the commander bump

## Breaking change
Grats now requires **Node.js >=22.12.0** (was `>=20`). This is a consequence of commander v15's own Node requirement.

## Verification
- No source changes needed — the CLI API we use (`Command`, `.version()`, `.option()`, `.action()`, `.parse()`) is unchanged in v15.
- `grats --help`, `grats --version`, and `grats locate --help` produce **identical output** under v14 and v15.
- `tsc --build` passes.
- Test suite: 504 fixtures pass. (One pre-existing failure in `customScalarSerialization` is unrelated to this change — it reproduces on `main` without these edits and is being investigated separately.)